### PR TITLE
Update layout settings in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,6 @@ layer-rule {
 layout {
     gaps 0
     center-focused-column "never"
-    focus-ring { off }
-    border { off }
 }
 
 animations {


### PR DESCRIPTION
Removed focus-ring and border settings from layout. 
These settings were preventing the kdl being parsed and running sysc-greet