### PR TITLE
run cached wallpaper on start

### DIFF
--- a/cmd/sysc-greet/main.go
+++ b/cmd/sysc-greet/main.go
@@ -687,6 +687,10 @@ func initialModel(config Config, screensaverMode bool) model {
 							FinalGradientDirection: "horizontal",
 						})
 					}
+				default:
+					if wallpaperFileName, isWallpaper := strings.CutPrefix(m.selectedBackground, "wallpaper:"); isWallpaper {
+						launchGslapperWallpaper(wallpaperFileName)
+					}
 				}
 			}
 


### PR DESCRIPTION
Issue #29: Cached preference background:"wallpaper:<filename>" not used