### PR TITLE
Fix NixOS setup when not using an Initial Session

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -154,6 +154,9 @@ EOF
 
             users.groups.greeter = { };
 
+            # Expose Sessions for sysc-greet to pick up
+            environment.pathsToLink = [ "/share/wayland-sessions" ];
+            
             # Configure greetd
             services.greetd = {
               enable = true;

--- a/internal/sessions/sessions.go
+++ b/internal/sessions/sessions.go
@@ -37,6 +37,8 @@ func LoadSessions() ([]Session, error) {
 	paths := []string{
 		"/usr/share/xsessions",
 		"/usr/share/wayland-sessions",
+		"/run/current-system/sw/share/xsessions",
+		"/run/current-system/sw/share/wayland-sessions",
 	}
 
 	for _, basePath := range paths {


### PR DESCRIPTION
Thanks for your Greeter, it's a very nice tool!
I stumbled upon a couple of issues, though, so here is a small patch to fix that if you are so inclined ☺️

# Context
* when not providing an `initial_session` option at configuration, the current flake defaults it to `{}`
    * depending to `greetd` version, it will search for the `command` key/value in this `Attribute Set` if present, leading to an error
* NixOS being sandboxed, `sysc-greet` will not have access to the standard directories to discover `Session` desktop files
    * the current version will show an empty Session list in this case

# Description
* Don't expose a  `initial_session` attribute set to `greetd` if none is provided to `sysc-greet`
* Add sand-boxed paths for Session discovery

Cheers!