### PR TITLE
feat(hyprland): add ecosystem config to suppress update/donation popups

### DIFF
--- a/cmd/installer/main.go
+++ b/cmd/installer/main.go
@@ -1519,6 +1519,12 @@ misc {
     disable_watchdog_warning = true
 }
 
+# Suppress annoying update/donation popups
+ecosystem {
+    no_update_news = true
+    no_donation_nag = true
+}
+
 # Input configuration
 input {
     kb_layout = us

--- a/config/hyprland-greeter-config.conf
+++ b/config/hyprland-greeter-config.conf
@@ -30,6 +30,12 @@ misc {
     disable_watchdog_warning = true
 }
 
+# Suppress annoying update/donation popups
+ecosystem {
+    no_update_news = true
+    no_donation_nag = true
+}
+
 # Input configuration
 input {
     kb_layout = us


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Disables Hyprland update/news and donation prompts in the greeter environment.
> 
> - Adds `ecosystem { no_update_news = true; no_donation_nag = true }` to the embedded Hyprland config in `cmd/installer/main.go`
> - Mirrors the same `ecosystem` block in `config/hyprland-greeter-config.conf`