### PR TITLE
Disable hot corners and enable numlock by default

### DIFF
--- a/config/niri-greeter-config.kdl
+++ b/config/niri-greeter-config.kdl
@@ -13,6 +13,7 @@ input {
         }
         repeat-delay 400
         repeat-rate 40
+        numlock
     }
 
     mouse {
@@ -22,6 +23,12 @@ input {
     touchpad {
         tap;
         // natural-scroll;
+    }
+}
+
+gestures {
+    hot-corners {
+        off
     }
 }
 


### PR DESCRIPTION
Hot corners are useless in a single-app environment (greeter in this case)

Numlock is an opinionated change, but I find it useful for numerical passwords, if you dislike it, just leave it there commented