### PR TITLE
feat: cagebreak packaging and install for Debian/Ubuntu/Fedora

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ on:
   push:
     tags:
       - 'v*'
+  # Dry run: builds everything, skips release creation
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -27,9 +29,15 @@ jobs:
       - name: Get version
         id: get_version
         run: |
-          VERSION=${GITHUB_REF#refs/tags/v}
+          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/v}
+            TAG=${GITHUB_REF#refs/tags/}
+          else
+            VERSION=0.0.0-dev
+            TAG=v0.0.0-dev
+          fi
           echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
-          echo "TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+          echo "TAG=$TAG" >> $GITHUB_OUTPUT
 
       - name: Build static binary
         run: |
@@ -44,6 +52,128 @@ jobs:
         run: |
           nfpm package --config nfpm.yaml --packager deb --target .
           nfpm package --config nfpm.yaml --packager rpm --target .
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: sysc-greet
+          path: |
+            sysc-greet
+            *.deb
+            *.rpm
+
+  # Cagebreak has no Debian/Ubuntu/Fedora packages. Build it per distro against
+  # that distro's wlroots (cagebreak pins wlroots per tag, no subproject
+  # fallback) and attach the packages to our releases for the installer.
+  # Version matrix: docs/superpowers/plans/2026-07-06-cagebreak-distro-packaging-plan.md
+  package-cagebreak:
+    runs-on: ubuntu-latest
+    container: ${{ matrix.image }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: "ubuntu:24.04"      # wlroots 0.17
+            cagebreak: "2.3.1"
+            pkgmgr: apt
+            packager: deb
+            pkgfile: cagebreak_2.3.1_ubuntu24.04_amd64.deb
+            # from ldd/dpkg -S inside the container (see plan doc)
+            depends: "libwlroots12t64 libwayland-server0 libxkbcommon0 libinput10 libudev1 libevdev2 libcairo2 libpango-1.0-0 libpangocairo-1.0-0 libglib2.0-0t64 libfontconfig1"
+          - image: "debian:13"         # wlroots 0.18; also serves Ubuntu 25.x
+            cagebreak: "2.4.0"
+            pkgmgr: apt
+            packager: deb
+            pkgfile: cagebreak_2.4.0_debian13_amd64.deb
+            depends: "libwlroots-0.18 libwayland-server0 libxkbcommon0 libinput10 libudev1 libevdev2 libcairo2 libpango-1.0-0 libpangocairo-1.0-0 libglib2.0-0t64 libfontconfig1"
+          - image: "fedora:42"         # wlroots 0.19
+            cagebreak: "3.1.0"
+            pkgmgr: dnf
+            packager: rpm
+            pkgfile: cagebreak-3.1.0-1.fedora42.x86_64.rpm
+            # soname capability for wlroots so dnf refuses on Fedora 43+
+            # (wlroots 0.20) instead of installing a broken binary
+            depends: "libwlroots-0.19.so()(64bit) libwayland-server libxkbcommon libinput systemd-libs libevdev cairo pango glib2 fontconfig"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install build dependencies (apt)
+        if: matrix.pkgmgr == 'apt'
+        run: |
+          export DEBIAN_FRONTEND=noninteractive
+          apt-get update -qq
+          # trixie ships libwlroots-0.18-dev, ubuntu 24.04 plain libwlroots-dev
+          WLROOTS_DEV=$(apt-cache search --names-only '^libwlroots(-0\.[0-9]+)?-dev$' | awk '{print $1}' | sort -rV | head -1)
+          apt-get install -y -qq --no-install-recommends \
+            git ca-certificates curl build-essential meson ninja-build pkg-config \
+            "$WLROOTS_DEV" libwayland-dev wayland-protocols libxkbcommon-dev \
+            libinput-dev libcairo2-dev libpango1.0-dev libfontconfig-dev \
+            libevdev-dev libudev-dev libpixman-1-dev
+
+      - name: Install build dependencies (dnf)
+        if: matrix.pkgmgr == 'dnf'
+        run: |
+          dnf install -y -q git curl gcc meson ninja-build pkgconf-pkg-config \
+            wlroots-devel wayland-devel wayland-protocols-devel libxkbcommon-devel \
+            libinput-devel cairo-devel pango-devel fontconfig-devel libevdev-devel \
+            systemd-devel pixman-devel
+
+      - name: Build cagebreak ${{ matrix.cagebreak }}
+        run: |
+          git clone --depth 1 --branch "${{ matrix.cagebreak }}" \
+            https://github.com/project-repo/cagebreak cagebreak
+          cd cagebreak
+          meson setup build
+          ninja -C build
+
+      - name: Smoke test against greeter config
+        run: |
+          # cagebreak refuses to run as root; containers run as root
+          useradd -m smoke
+          mkdir -p /tmp/runtime && chown smoke /tmp/runtime && chmod 700 /tmp/runtime
+          rc=0
+          su smoke -s /bin/sh -c "XDG_RUNTIME_DIR=/tmp/runtime WLR_BACKENDS=headless WLR_LIBINPUT_NO_DEVICES=1 \
+            timeout 5 $PWD/cagebreak/build/cagebreak -e -c $PWD/config/cagebreak-greeter-config" || rc=$?
+          # 124 = ran until timeout (config parsed, compositor up); 0 = clean exit
+          if [ "$rc" -ne 124 ] && [ "$rc" -ne 0 ]; then
+            echo "smoke test failed with rc=$rc"
+            exit 1
+          fi
+
+      - name: Install nfpm
+        run: |
+          curl -fsSL "https://github.com/goreleaser/nfpm/releases/download/v2.47.0/nfpm_2.47.0_Linux_x86_64.tar.gz" \
+            | tar -xz -C /usr/local/bin nfpm
+
+      - name: Package
+        env:
+          CAGEBREAK_VERSION: ${{ matrix.cagebreak }}
+          CAGEBREAK_DEPENDS: ${{ matrix.depends }}
+        run: |
+          # nfpm-cagebreak.yaml ends with a bare `depends:` key; append the
+          # per-distro runtime libs as list items (rpm needs individual entries)
+          for dep in $CAGEBREAK_DEPENDS; do
+            printf '  - "%s"\n' "$dep" >> nfpm-cagebreak.yaml
+          done
+          nfpm package --config nfpm-cagebreak.yaml \
+            --packager ${{ matrix.packager }} --target "${{ matrix.pkgfile }}"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.pkgfile }}
+          path: ${{ matrix.pkgfile }}
+
+  release:
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: [build, package-cagebreak]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
 
       - name: Generate checksums
         run: |

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ yay -S sysc-greet-hyprland
 yay -S sysc-greet-sway
 ```
 
-For cagebreak, install it from the AUR (`paru -S cagebreak`, plus `socat`) and run the installer with `SYSC_COMPOSITOR=cagebreak`.
+For cagebreak, run the installer with `SYSC_COMPOSITOR=cagebreak` — it installs cagebreak and socat itself (AUR on Arch, prebuilt release packages on Debian/Ubuntu/Fedora, source build elsewhere).
 
 ### NixOS (Flake)
 

--- a/cmd/installer/main.go
+++ b/cmd/installer/main.go
@@ -2,8 +2,11 @@ package main
 
 import (
 	"fmt"
+	"io"
+	"net/http"
 	"os"
 	"os/exec"
+	"runtime"
 	"strings"
 	"time"
 
@@ -394,7 +397,10 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					}
 				}
 
-				if !compositorInstalled {
+				// cagebreak is installable by the installer itself (repo/AUR on
+				// Arch, release artifact or source build elsewhere); everything
+				// else must be present up front
+				if !compositorInstalled && m.selectedCompositor != "cagebreak" {
 					m.errors = append(m.errors, fmt.Sprintf("%s is not installed - please install it first", m.selectedCompositor))
 					// Stay on compositor selection screen
 					return m, nil
@@ -975,7 +981,262 @@ func installCagebreakArch() error {
 	return nil
 }
 
+// ensureSocat installs socat, which the cagebreak greeter config needs to quit
+// the compositor after login (echo quit | socat - UNIX-CONNECT:$CAGEBREAK_SOCKET).
+func ensureSocat(m *model) error {
+	if _, err := exec.LookPath("socat"); err == nil {
+		return nil
+	}
+	var cmd *exec.Cmd
+	switch m.packageManager {
+	case "pacman":
+		cmd = exec.Command("pacman", "-S", "--noconfirm", "socat")
+	case "apt":
+		cmd = exec.Command("apt-get", "install", "-y", "socat")
+	case "dnf":
+		cmd = exec.Command("dnf", "install", "-y", "socat")
+	case "yum":
+		cmd = exec.Command("yum", "install", "-y", "socat")
+	case "zypper":
+		cmd = exec.Command("zypper", "install", "-y", "socat")
+	default:
+		return fmt.Errorf("socat is required for cagebreak — install it manually")
+	}
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to install socat (cagebreak cannot quit after login without it)")
+	}
+	return nil
+}
+
+// cagebreakArtifact returns the prebuilt cagebreak package from sysc-greet
+// releases matching this distro, or "" when none matches (source build instead).
+// Cagebreak pins wlroots per tag, so each artifact is built against one
+// distro's wlroots — matrix in docs/superpowers/plans/2026-07-06-cagebreak-distro-packaging-plan.md.
+func cagebreakArtifact() string {
+	if runtime.GOARCH != "amd64" {
+		return ""
+	}
+	data, err := os.ReadFile("/etc/os-release")
+	if err != nil {
+		return ""
+	}
+	var id, version string
+	for _, line := range strings.Split(string(data), "\n") {
+		if v := strings.TrimPrefix(line, "ID="); v != line {
+			id = strings.Trim(v, `"`)
+		}
+		if v := strings.TrimPrefix(line, "VERSION_ID="); v != line {
+			version = strings.Trim(v, `"`)
+		}
+	}
+	switch id {
+	case "ubuntu":
+		if version == "24.04" {
+			return "cagebreak_2.3.1_ubuntu24.04_amd64.deb"
+		}
+		// Ubuntu 25.x ships wlroots 0.18 under the same package names as trixie
+		if strings.HasPrefix(version, "25.") {
+			return "cagebreak_2.4.0_debian13_amd64.deb"
+		}
+	case "debian":
+		if version == "13" {
+			return "cagebreak_2.4.0_debian13_amd64.deb"
+		}
+	case "fedora":
+		if version == "42" {
+			return "cagebreak-3.1.0-1.fedora42.x86_64.rpm"
+		}
+	}
+	return ""
+}
+
+func downloadFile(url, dest string) error {
+	resp, err := http.Get(url)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("download failed: %s", resp.Status)
+	}
+	f, err := os.Create(dest)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	_, err = io.Copy(f, resp.Body)
+	return err
+}
+
+// installCagebreakPrebuilt installs the cagebreak package attached to the
+// latest sysc-greet release; any miss falls back to building from source.
+func installCagebreakPrebuilt(m *model) error {
+	artifact := cagebreakArtifact()
+	if artifact == "" {
+		return buildCagebreakFromSource(m)
+	}
+	path := "/tmp/" + artifact
+	url := "https://github.com/Nomadcxx/sysc-greet/releases/latest/download/" + artifact
+	if err := downloadFile(url, path); err != nil {
+		return buildCagebreakFromSource(m)
+	}
+	defer os.Remove(path)
+	var cmd *exec.Cmd
+	switch m.packageManager {
+	case "apt":
+		cmd = exec.Command("apt-get", "install", "-y", path)
+	case "dnf":
+		cmd = exec.Command("dnf", "install", "-y", path)
+	default:
+		return buildCagebreakFromSource(m)
+	}
+	if err := runCommand("Install cagebreak package", cmd, m); err != nil {
+		return buildCagebreakFromSource(m)
+	}
+	return nil
+}
+
+// getCagebreakBuildDeps returns distro package names for building cagebreak.
+// The apt wlroots dev package is resolved separately (name carries the version
+// on trixie: libwlroots-0.18-dev vs plain libwlroots-dev on Ubuntu 24.04).
+func getCagebreakBuildDeps(packageManager string) []string {
+	switch packageManager {
+	case "apt":
+		return []string{
+			"git", "ca-certificates", "build-essential", "meson", "ninja-build", "pkg-config",
+			"libwayland-dev", "wayland-protocols", "libxkbcommon-dev", "libinput-dev",
+			"libcairo2-dev", "libpango1.0-dev", "libfontconfig-dev", "libevdev-dev",
+			"libudev-dev", "libpixman-1-dev",
+		}
+	case "dnf", "yum":
+		return []string{
+			"git", "gcc", "meson", "ninja-build", "pkgconf-pkg-config",
+			"wlroots-devel", "wayland-devel", "wayland-protocols-devel", "libxkbcommon-devel",
+			"libinput-devel", "cairo-devel", "pango-devel", "fontconfig-devel",
+			"libevdev-devel", "systemd-devel", "pixman-devel",
+		}
+	case "zypper":
+		return []string{
+			"git", "gcc", "meson", "ninja", "pkg-config",
+			"wlroots-devel", "wayland-devel", "wayland-protocols-devel", "libxkbcommon-devel",
+			"libinput-devel", "cairo-devel", "pango-devel", "fontconfig-devel",
+			"libevdev-devel", "systemd-devel", "pixman-devel",
+		}
+	}
+	return nil
+}
+
+// cagebreakTagForWlroots maps the installed wlroots dev headers to the newest
+// cagebreak tag that builds against them (no meson subproject fallback upstream).
+func cagebreakTagForWlroots() (string, error) {
+	probes := []struct{ module, tag string }{
+		{"wlroots-0.20", "3.2.1"},
+		{"wlroots-0.19", "3.1.0"},
+		{"wlroots-0.18", "2.4.0"},
+		{"wlroots", "2.3.1"}, // 0.17 uses the unversioned pkg-config name
+	}
+	for _, p := range probes {
+		if exec.Command("pkg-config", "--exists", p.module).Run() != nil {
+			continue
+		}
+		if p.module == "wlroots" {
+			out, err := exec.Command("pkg-config", "--modversion", "wlroots").Output()
+			if err != nil || !strings.HasPrefix(strings.TrimSpace(string(out)), "0.17") {
+				continue
+			}
+		}
+		return p.tag, nil
+	}
+	return "", fmt.Errorf("no usable wlroots headers found (cagebreak needs wlroots 0.17–0.20)")
+}
+
+// buildCagebreakFromSource mirrors buildGslapperFromSource: install build deps,
+// pick the cagebreak tag matching the system wlroots, meson build, install.
+func buildCagebreakFromSource(m *model) error {
+	deps := getCagebreakBuildDeps(m.packageManager)
+	if deps == nil {
+		return fmt.Errorf("cagebreak not packaged for this distro — build it from https://github.com/project-repo/cagebreak")
+	}
+
+	if m.packageManager == "apt" {
+		// Resolve the versioned wlroots dev package name
+		wlrootsDev := ""
+		for _, candidate := range []string{"libwlroots-0.20-dev", "libwlroots-0.19-dev", "libwlroots-0.18-dev", "libwlroots-dev"} {
+			if checkPackageExists(candidate, "apt") {
+				wlrootsDev = candidate
+				break
+			}
+		}
+		if wlrootsDev == "" {
+			return fmt.Errorf("no libwlroots dev package in apt repos — cagebreak cannot be built here")
+		}
+		deps = append(deps, wlrootsDev)
+	}
+
+	var cmd *exec.Cmd
+	switch m.packageManager {
+	case "apt":
+		cmd = exec.Command("apt-get", append([]string{"install", "-y"}, deps...)...)
+	case "dnf":
+		cmd = exec.Command("dnf", append([]string{"install", "-y"}, deps...)...)
+	case "yum":
+		cmd = exec.Command("yum", append([]string{"install", "-y"}, deps...)...)
+	case "zypper":
+		cmd = exec.Command("zypper", append([]string{"install", "-y"}, deps...)...)
+	}
+	if cmd != nil {
+		runCommand("Install cagebreak build deps", cmd, m) // Best effort; verified below
+	}
+
+	for _, tool := range []string{"meson", "ninja", "git", "pkg-config"} {
+		if _, err := exec.LookPath(tool); err != nil {
+			return fmt.Errorf("missing build tool: %s", tool)
+		}
+	}
+
+	tag, err := cagebreakTagForWlroots()
+	if err != nil {
+		return err
+	}
+
+	exec.Command("rm", "-rf", "/tmp/cagebreak-build").Run()
+	cloneCmd := exec.Command("git", "clone", "--depth", "1", "--branch", tag,
+		"https://github.com/project-repo/cagebreak", "/tmp/cagebreak-build")
+	if err := runCommand("Clone cagebreak", cloneCmd, m); err != nil {
+		return fmt.Errorf("cagebreak clone failed")
+	}
+
+	setupCmd := exec.Command("meson", "setup", "build")
+	setupCmd.Dir = "/tmp/cagebreak-build"
+	if err := runCommand("Configure cagebreak build", setupCmd, m); err != nil {
+		return fmt.Errorf("cagebreak build setup failed — check wlroots dev packages")
+	}
+
+	buildCmd := exec.Command("ninja", "-C", "build")
+	buildCmd.Dir = "/tmp/cagebreak-build"
+	if err := runCommand("Build cagebreak", buildCmd, m); err != nil {
+		return fmt.Errorf("cagebreak build failed")
+	}
+
+	installCmd := exec.Command("install", "-Dm755", "build/cagebreak", "/usr/local/bin/cagebreak")
+	installCmd.Dir = "/tmp/cagebreak-build"
+	if err := runCommand("Install cagebreak", installCmd, m); err != nil {
+		return fmt.Errorf("cagebreak install failed")
+	}
+
+	exec.Command("rm", "-rf", "/tmp/cagebreak-build").Run()
+	return nil
+}
+
 func installCompositor(m *model) error {
+	// The cagebreak greeter config quits the compositor via socat, even when
+	// cagebreak itself is already installed
+	if m.selectedCompositor == "cagebreak" {
+		if err := ensureSocat(m); err != nil {
+			return err
+		}
+	}
+
 	// Map compositor selection to binary names
 	compositorBinaries := map[string][]string{
 		"niri":      {"niri"},
@@ -1039,7 +1300,7 @@ func installCompositor(m *model) error {
 		case "sway":
 			cmd = exec.Command("apt-get", "install", "-y", "sway")
 		case "cagebreak":
-			return fmt.Errorf("cagebreak not in standard apt repos — build from https://github.com/project-repo/cagebreak")
+			return installCagebreakPrebuilt(m)
 		}
 
 	case "dnf":
@@ -1052,7 +1313,7 @@ func installCompositor(m *model) error {
 		case "sway":
 			cmd = exec.Command("dnf", "install", "-y", "sway")
 		case "cagebreak":
-			return fmt.Errorf("cagebreak not in standard dnf repos — build from https://github.com/project-repo/cagebreak")
+			return installCagebreakPrebuilt(m)
 		}
 
 	case "yum":
@@ -1071,6 +1332,12 @@ func installCompositor(m *model) error {
 			return fmt.Errorf("hyprland may require Tumbleweed or manual install")
 		case "sway":
 			cmd = exec.Command("zypper", "install", "-y", "sway")
+		case "cagebreak":
+			// Packaged in Tumbleweed; source build covers anything else
+			if err := exec.Command("zypper", "install", "-y", "cagebreak").Run(); err != nil {
+				return buildCagebreakFromSource(m)
+			}
+			return nil
 		default:
 			return fmt.Errorf("%s may not be in zypper repos - install manually", m.selectedCompositor)
 		}

--- a/docs-src/compositors/cagebreak.md
+++ b/docs-src/compositors/cagebreak.md
@@ -8,13 +8,25 @@ The greeter config is ~10 lines, defines no keybindings, and quits the composito
 
 ## Install Cagebreak
 
+The installer handles all of this — including socat, which is required to quit the compositor after login. The sections below are for manual installs.
+
 === "Arch Linux"
 
-    Cagebreak is in the AUR, not the official repos. socat is required to quit the compositor after login.
+    Cagebreak is in the AUR, not the official repos. The installer uses paru or yay if present; manually:
 
     ```bash
     paru -S cagebreak   # or: yay -S cagebreak
     sudo pacman -S socat
+    ```
+
+=== "Debian / Ubuntu / Fedora"
+
+    No distro packages exist. The installer downloads a cagebreak package built against your distro's wlroots from [sysc-greet releases](https://github.com/Nomadcxx/sysc-greet/releases/latest) (Debian 13, Ubuntu 24.04/25.x, Fedora 42), and builds from source when no package matches. Manual install:
+
+    ```bash
+    # Debian 13 / Ubuntu 25.x
+    wget https://github.com/Nomadcxx/sysc-greet/releases/latest/download/cagebreak_2.4.0_debian13_amd64.deb
+    sudo apt install ./cagebreak_2.4.0_debian13_amd64.deb socat
     ```
 
 === "NixOS"
@@ -27,9 +39,17 @@ The greeter config is ~10 lines, defines no keybindings, and quits the composito
     };
     ```
 
+=== "openSUSE"
+
+    Tumbleweed packages cagebreak:
+
+    ```bash
+    sudo zypper install cagebreak socat
+    ```
+
 === "Other distros"
 
-    Check your package manager or build from [project-repo/cagebreak](https://github.com/project-repo/cagebreak).
+    Check your package manager or build from [project-repo/cagebreak](https://github.com/project-repo/cagebreak). The buildable release depends on your wlroots version: 0.17 → 2.3.1, 0.18 → 2.4.0, 0.19 → 3.1.0, 0.20 → 3.2.1.
 
 ## greetd Config
 

--- a/docs/superpowers/plans/2026-07-06-cagebreak-distro-packaging-plan.md
+++ b/docs/superpowers/plans/2026-07-06-cagebreak-distro-packaging-plan.md
@@ -65,17 +65,25 @@ irrelevant to the greeter.
 
 Common to all tags: meson, ninja, wlroots (devel), wayland-server/client/cursor,
 wayland-protocols, xkbcommon, libinput, cairo, pango + pangocairo, fontconfig,
-libevdev, libudev, pixman-1, scdoc (man pages, optional via
-`-Dman-pages=false`).
+libevdev, libudev, pixman-1. Man pages default off and need pandoc — skipped.
 
 Debian/Ubuntu package names: `meson ninja-build libwlroots-dev libwayland-dev
 wayland-protocols libxkbcommon-dev libinput-dev libcairo2-dev libpango1.0-dev
 libfontconfig-dev libevdev-dev libudev-dev libpixman-1-dev`
-(trixie names the wlroots package `libwlroots-0.18-dev`).
+(trixie names the wlroots package `libwlroots-0.18-dev` — probe with
+`apt-cache search '^libwlroots(-0\.[0-9]+)?-dev$'`).
 
 Fedora package names: `meson ninja-build wlroots-devel wayland-devel
 wayland-protocols-devel libxkbcommon-devel libinput-devel cairo-devel
 pango-devel fontconfig-devel libevdev-devel systemd-devel pixman-devel`.
+
+Validated 2026-07-07 in local containers (debian:13/2.4.0, ubuntu:24.04/2.3.1,
+fedora:42/3.1.0): all three build and pass the headless smoke test. Two CI
+gotchas found: **cagebreak refuses to start as root**, so the smoke test must
+run as an unprivileged user (containers default to root); and nfpm expands env
+vars per-scalar only, so per-distro `depends` are appended to
+`nfpm-cagebreak.yaml` as YAML list items by the workflow (a comma-joined
+single string produces one bogus RPM Requires entry).
 
 ### wlroots detection (for the source-build fallback)
 
@@ -152,11 +160,12 @@ distro string.
 
 ### A3. Tasks
 
-- [ ] `nfpm-cagebreak.yaml` with env-driven version/depends
-- [ ] `package-cagebreak` matrix job in `release.yml` per A1
-- [ ] Headless smoke test step against `config/cagebreak-greeter-config`
-- [ ] Attach artifacts + extend SHA256SUMS in the release job
+- [x] `nfpm-cagebreak.yaml` with env-driven version/depends
+- [x] `package-cagebreak` matrix job in `release.yml` per A1
+- [x] Headless smoke test step against `config/cagebreak-greeter-config`
+- [x] Attach artifacts + extend SHA256SUMS in the release job
 - [ ] Dry-run via `workflow_dispatch` trigger before tagging a real release
+      (trigger added; run it once this lands on `development`)
 
 ## Phase B — installer integration
 
@@ -193,11 +202,16 @@ Mirror `buildGslapperFromSource` (~`cmd/installer/main.go:1093`):
 
 ### B3. Tasks
 
-- [ ] `installCagebreakDebian` / `installCagebreakFedora` artifact fetch
-- [ ] `buildCagebreakFromSource` fallback with wlroots probe
-- [ ] Replace the current manual-build error message with the above flow
-- [ ] `socat` added to the cagebreak dep set on apt/dnf (already handled on Arch)
-- [ ] Docs: per-distro install section in `docs-src/compositors/cagebreak.md`
+- [x] `installCagebreakPrebuilt` artifact fetch (os-release → artifact mapping)
+- [x] `buildCagebreakFromSource` fallback with wlroots probe
+- [x] Replace the current manual-build error message with the above flow
+- [x] `ensureSocat` on every cagebreak path (Arch included — it was missing
+      there too; runs even when cagebreak is pre-installed)
+- [x] zypper: install Tumbleweed's packaged cagebreak, source build fallback
+- [x] Selection screen no longer blocks on missing cagebreak (the installer
+      can now install it; other compositors still must be present up front)
+- [x] Docs: per-distro install section in `docs-src/compositors/cagebreak.md`;
+      README cagebreak note
 
 ## Phase C — validation
 

--- a/docs/superpowers/plans/2026-07-06-cagebreak-distro-packaging-plan.md
+++ b/docs/superpowers/plans/2026-07-06-cagebreak-distro-packaging-plan.md
@@ -1,0 +1,64 @@
+# Cagebreak Packaging for Debian/Fedora — Plan (stub)
+
+> **Status:** Stub — approach decided, implementation not started
+> **Follows:** PR #78 (cagebreak greeter backend, merged to `development`)
+> **Blocks:** Hyprland greeter removal on apt/dnf distros
+
+## Problem
+
+Cagebreak is packaged for Arch (AUR), NixOS, Alpine, Void, and the BSDs. It is
+absent from Debian, Ubuntu, and Fedora repos. sysc-greet supports those distros,
+so the hyprland → cagebreak migration has no install path there.
+
+Cagebreak is C, dynamically linked against wlroots. A single binary is not
+portable across distros the way the static sysc-greet Go binary is, and distro
+wlroots versions (0.17–0.20) pin which cagebreak release can build.
+
+## Decision (2026-07-06)
+
+1. **Primary — release CI artifacts.** Extend `.github/workflows/release.yml`
+   with per-distro container jobs (debian, ubuntu LTS, fedora) that build
+   cagebreak against each distro's wlroots and package it with nfpm as a
+   separate `cagebreak_<ver>_<distro>.deb/.rpm` attached to sysc-greet GitHub
+   releases. The installer on apt/dnf installs that artifact.
+2. **Fallback — installer source build.** Mirror the gslapper pattern
+   (`buildGslapperFromSource`): distro dep lists (meson, ninja, libwlroots-dev,
+   libxkbcommon-dev, wayland-protocols, scdoc) plus wlroots-version →
+   cagebreak-tag selection. Used only where no artifact exists.
+3. Upstream packaging PR to project-repo/cagebreak: rejected as redundant —
+   distro inclusion needs maintainers/sponsorship a PR cannot shortcut, and our
+   artifacts serve users either way.
+
+## Tasks
+
+### Phase A — CI artifacts (primary)
+
+- [ ] Map wlroots version per target: debian:13, ubuntu:24.04, fedora:42
+- [ ] Pick buildable cagebreak tag per wlroots version (greeter config needs
+      only `background`, `exec`, `-c`, `-e`; 2.x suffices)
+- [ ] Test wlroots as meson subproject — if cagebreak supports it, the matrix
+      may collapse to one job per package format
+- [ ] Container build jobs in `release.yml`; nfpm config `nfpm-cagebreak.yaml`
+- [ ] Headless smoke test in CI (`WLR_BACKENDS=headless cagebreak -e -c ...`)
+- [ ] Attach artifacts + SHA256SUMS to releases
+
+### Phase B — installer integration
+
+- [ ] apt/dnf path: fetch matching artifact from GitHub releases, install via
+      `dpkg -i` / `dnf install`
+- [ ] Source-build fallback `buildCagebreakFromSource` when no artifact matches
+- [ ] Replace the current "build from https://github.com/project-repo/cagebreak"
+      error with the above
+- [ ] Docs: `docs-src/compositors/cagebreak.md` install section per distro
+
+### Phase C — validation
+
+- [ ] Debian VM/container: install → greetd → login
+- [ ] Fedora VM/container: install → greetd → login
+- [ ] openSUSE: verify the packaged 2.3.1 works with the greeter config
+
+## Non-goals
+
+- Bundling cagebreak inside the sysc-greet package (file conflicts if a distro
+  ever packages it; couples our release to a compositor we don't maintain)
+- Getting cagebreak into official Debian/Fedora repos

--- a/docs/superpowers/plans/2026-07-06-cagebreak-distro-packaging-plan.md
+++ b/docs/superpowers/plans/2026-07-06-cagebreak-distro-packaging-plan.md
@@ -1,6 +1,6 @@
-# Cagebreak Packaging for Debian/Fedora — Plan (stub)
+# Cagebreak Packaging for Debian/Fedora — Plan
 
-> **Status:** Stub — approach decided, implementation not started
+> **Status:** Implementation plan — approach decided 2026-07-06, research complete 2026-07-07
 > **Follows:** PR #78 (cagebreak greeter backend, merged to `development`)
 > **Blocks:** Hyprland greeter removal on apt/dnf distros
 
@@ -17,48 +17,204 @@ wlroots versions (0.17–0.20) pin which cagebreak release can build.
 ## Decision (2026-07-06)
 
 1. **Primary — release CI artifacts.** Extend `.github/workflows/release.yml`
-   with per-distro container jobs (debian, ubuntu LTS, fedora) that build
-   cagebreak against each distro's wlroots and package it with nfpm as a
-   separate `cagebreak_<ver>_<distro>.deb/.rpm` attached to sysc-greet GitHub
-   releases. The installer on apt/dnf installs that artifact.
+   with per-distro container jobs that build cagebreak against each distro's
+   wlroots and package it with nfpm as a separate
+   `cagebreak_<ver>_<distro>.deb/.rpm` attached to sysc-greet GitHub releases.
+   The installer on apt/dnf installs that artifact.
 2. **Fallback — installer source build.** Mirror the gslapper pattern
-   (`buildGslapperFromSource`): distro dep lists (meson, ninja, libwlroots-dev,
-   libxkbcommon-dev, wayland-protocols, scdoc) plus wlroots-version →
-   cagebreak-tag selection. Used only where no artifact exists.
+   (`buildGslapperFromSource` in `cmd/installer/main.go`): per-distro dep
+   lists plus wlroots-version → cagebreak-tag selection. Used only where no
+   artifact matches.
 3. Upstream packaging PR to project-repo/cagebreak: rejected as redundant —
    distro inclusion needs maintainers/sponsorship a PR cannot shortcut, and our
    artifacts serve users either way.
 
-## Tasks
+## Research findings (2026-07-07)
 
-### Phase A — CI artifacts (primary)
+### wlroots requirement per cagebreak tag
 
-- [ ] Map wlroots version per target: debian:13, ubuntu:24.04, fedora:42
-- [ ] Pick buildable cagebreak tag per wlroots version (greeter config needs
-      only `background`, `exec`, `-c`, `-e`; 2.x suffices)
-- [ ] Test wlroots as meson subproject — if cagebreak supports it, the matrix
-      may collapse to one job per package format
-- [ ] Container build jobs in `release.yml`; nfpm config `nfpm-cagebreak.yaml`
-- [ ] Headless smoke test in CI (`WLR_BACKENDS=headless cagebreak -e -c ...`)
-- [ ] Attach artifacts + SHA256SUMS to releases
+Verified against each tag's `meson.build`. Cagebreak has **no meson subproject
+fallback for wlroots** — the system wlroots version dictates the buildable tag.
+The stub's "test wlroots as meson subproject" task is dead; removed.
 
-### Phase B — installer integration
+| cagebreak tag | wlroots requirement |
+|---|---|
+| 3.2.1 (2026-06) | wlroots-0.20 |
+| 3.1.0 | wlroots-0.19 |
+| 3.0.1 | wlroots-0.19 |
+| 2.4.0 | wlroots-0.18 |
+| 2.3.1 | >= 0.17.0, < 0.18.0 |
 
-- [ ] apt/dnf path: fetch matching artifact from GitHub releases, install via
-      `dpkg -i` / `dnf install`
-- [ ] Source-build fallback `buildCagebreakFromSource` when no artifact matches
-- [ ] Replace the current "build from https://github.com/project-repo/cagebreak"
-      error with the above
-- [ ] Docs: `docs-src/compositors/cagebreak.md` install section per distro
+### wlroots shipped per target distro
 
-### Phase C — validation
+| Distro | wlroots | Buildable cagebreak |
+|---|---|---|
+| Ubuntu 24.04 LTS | 0.17.1 | 2.3.1 |
+| Debian 13 (trixie, stable) | 0.18.2 | 2.4.0 |
+| Ubuntu 25.04 / 25.10 | 0.18.2 (+0.17.4 compat) | 2.4.0 |
+| Fedora 41 | 0.18.2 | 2.4.0 |
+| Fedora 42 | 0.19.2 (+0.18.2 compat) | 3.1.0 |
+| Debian sid / Fedora rawhide / Tumbleweed | 0.20.1 | 3.2.1 |
+| openSUSE Leap | 0.14.1 | none — unsupported |
 
-- [ ] Debian VM/container: install → greetd → login
-- [ ] Fedora VM/container: install → greetd → login
-- [ ] openSUSE: verify the packaged 2.3.1 works with the greeter config
+Old tags are fine: the greeter config uses only `background`, `exec`, `-c`,
+and `-e`, all present since 2.x. Feature drift between 2.3.1 and 3.2.1 is
+irrelevant to the greeter.
+
+### Build dependencies
+
+Common to all tags: meson, ninja, wlroots (devel), wayland-server/client/cursor,
+wayland-protocols, xkbcommon, libinput, cairo, pango + pangocairo, fontconfig,
+libevdev, libudev, pixman-1, scdoc (man pages, optional via
+`-Dman-pages=false`).
+
+Debian/Ubuntu package names: `meson ninja-build libwlroots-dev libwayland-dev
+wayland-protocols libxkbcommon-dev libinput-dev libcairo2-dev libpango1.0-dev
+libfontconfig-dev libevdev-dev libudev-dev libpixman-1-dev`
+(trixie names the wlroots package `libwlroots-0.18-dev`).
+
+Fedora package names: `meson ninja-build wlroots-devel wayland-devel
+wayland-protocols-devel libxkbcommon-devel libinput-devel cairo-devel
+pango-devel fontconfig-devel libevdev-devel systemd-devel pixman-devel`.
+
+### wlroots detection (for the source-build fallback)
+
+pkg-config module names differ by version: `wlroots-0.20`, `wlroots-0.19`,
+`wlroots-0.18` for modern releases; plain `wlroots` for 0.17. Probe from newest
+to oldest with `pkg-config --exists`, map the first hit to a tag via the table
+above.
+
+## Phase A — CI artifacts (primary)
+
+### A1. Build matrix in `release.yml`
+
+New `package-cagebreak` job (runs alongside the existing `build` job on tag
+push), one matrix entry per target:
+
+```yaml
+package-cagebreak:
+  runs-on: ubuntu-latest
+  container: ${{ matrix.image }}
+  strategy:
+    matrix:
+      include:
+        - { image: "ubuntu:24.04", cagebreak: "2.3.1", packager: deb, suffix: ubuntu24.04 }
+        - { image: "debian:13",    cagebreak: "2.4.0", packager: deb, suffix: debian13 }
+        - { image: "fedora:42",    cagebreak: "3.1.0", packager: rpm, suffix: fedora42 }
+  steps:
+    # 1. install build deps (apt/dnf per image)
+    # 2. git clone --depth 1 --branch <tag> https://github.com/project-repo/cagebreak
+    # 3. meson setup build -Dman-pages=false && ninja -C build
+    # 4. smoke test: WLR_BACKENDS=headless WLR_LIBINPUT_NO_DEVICES=1 \
+    #      timeout 5 ./build/cagebreak -e -c config/cagebreak-greeter-config
+    #    (exit 124 = parsed and ran; anything else fails the job)
+    # 5. nfpm package --config nfpm-cagebreak.yaml --packager <packager>
+    # 6. upload-artifact
+```
+
+The existing release-create step gains a download-artifact step and attaches
+`cagebreak_*` packages plus their checksums to the same release.
+
+Notes:
+- Not added to the sysc-greet package itself (see Non-goals).
+- Debian 13 artifact also serves Ubuntu 25.x and is documented as such;
+  we do not build a fourth image for it.
+- Fedora 41 skipped: EOL before this ships; users there get the source-build
+  fallback (wlroots 0.18 → tag 2.4.0).
+
+### A2. `nfpm-cagebreak.yaml`
+
+Modeled on `nfpm.yaml`, but packaging the compositor binary only:
+
+```yaml
+name: cagebreak
+arch: amd64
+version: ${CAGEBREAK_VERSION}     # the cagebreak tag, not the sysc-greet tag
+maintainer: Nomadcxx
+description: Cagebreak Wayland compositor (built for sysc-greet greeter use)
+license: MIT
+depends: ${CAGEBREAK_DEPENDS}     # per-distro runtime libs, set by the matrix
+contents:
+  - src: ./cagebreak/build/cagebreak
+    dst: /usr/bin/cagebreak
+```
+
+Runtime `depends` must be explicit per target (nfpm does not compute shared-lib
+deps the way debhelper does): e.g. trixie `libwlroots-0.18, libpango-1.0-0,
+libcairo2, libinput10, libxkbcommon0, libevdev2, libfontconfig1`, Fedora
+`wlroots, pango, cairo, libinput, libxkbcommon, libevdev, fontconfig`.
+Verify exact soname-package names inside each container during implementation
+(`dpkg -S`/`dnf provides` on the linked libs from `ldd`).
+
+Output naming: `cagebreak_<version>_<suffix>_amd64.deb` /
+`cagebreak-<version>-1.<suffix>.x86_64.rpm` so the installer can select by
+distro string.
+
+### A3. Tasks
+
+- [ ] `nfpm-cagebreak.yaml` with env-driven version/depends
+- [ ] `package-cagebreak` matrix job in `release.yml` per A1
+- [ ] Headless smoke test step against `config/cagebreak-greeter-config`
+- [ ] Attach artifacts + extend SHA256SUMS in the release job
+- [ ] Dry-run via `workflow_dispatch` trigger before tagging a real release
+
+## Phase B — installer integration
+
+### B1. Artifact fetch path (apt/dnf)
+
+In `cmd/installer/main.go`, new `installCagebreakDebian` / `installCagebreakFedora`
+called from the compositor-install switch where the current "build from
+https://github.com/project-repo/cagebreak" error sits:
+
+1. Detect distro + version (`/etc/os-release` ID + VERSION_ID, already parsed
+   for gslapper deps).
+2. Map to artifact suffix: ubuntu 24.04 → `ubuntu24.04`; debian 13 / ubuntu
+   25.x → `debian13`; fedora 42+ → `fedora42`.
+3. Download from the latest sysc-greet release
+   (`https://github.com/Nomadcxx/sysc-greet/releases/latest/download/<name>`),
+   verify against SHA256SUMS, install via `apt install ./<file>` /
+   `dnf install ./<file>` (resolves the declared lib deps).
+4. No matching artifact (unknown distro, arm64, sid-class wlroots 0.20) →
+   fall through to B2.
+
+### B2. Source-build fallback `buildCagebreakFromSource`
+
+Mirror `buildGslapperFromSource` (~`cmd/installer/main.go:1093`):
+
+1. Install build deps via the per-distro lists from Research findings
+   (extend the existing dep-install helpers the way `getGStreamerDeps` does).
+2. Probe wlroots: `pkg-config --exists wlroots-0.20 / -0.19 / -0.18 / wlroots`
+   newest-first; map hit → tag (0.20→3.2.1, 0.19→3.1.0, 0.18→2.4.0,
+   0.17→2.3.1). No hit → error naming the missing `-dev`/`-devel` package.
+3. `git clone --depth 1 --branch <tag>`, `meson setup build -Dman-pages=false`,
+   `ninja -C build`, install binary to `/usr/local/bin/cagebreak`.
+4. Verify with the same headless parse test used by
+   `scripts/verify-cagebreak-greeter.sh`.
+
+### B3. Tasks
+
+- [ ] `installCagebreakDebian` / `installCagebreakFedora` artifact fetch
+- [ ] `buildCagebreakFromSource` fallback with wlroots probe
+- [ ] Replace the current manual-build error message with the above flow
+- [ ] `socat` added to the cagebreak dep set on apt/dnf (already handled on Arch)
+- [ ] Docs: per-distro install section in `docs-src/compositors/cagebreak.md`
+
+## Phase C — validation
+
+- [ ] Debian 13 container/VM: installer → artifact install → greetd config →
+      headless greeter smoke test
+- [ ] Ubuntu 24.04 container/VM: same via the 2.3.1 artifact
+- [ ] Fedora 42 container/VM: same via the 3.1.0 rpm
+- [ ] Source-build fallback exercised once on a target without artifacts
+- [ ] openSUSE Tumbleweed: verify packaged cagebreak (2.3.1 in repos) or the
+      0.20 source build works with the greeter config
+- [ ] Real-hardware login test on at least one apt distro before flipping any
+      hyprland-removal switch
 
 ## Non-goals
 
 - Bundling cagebreak inside the sysc-greet package (file conflicts if a distro
   ever packages it; couples our release to a compositor we don't maintain)
 - Getting cagebreak into official Debian/Fedora repos
+- openSUSE Leap support (wlroots 0.14 predates every cagebreak tag we can use)
+- arm64 artifacts (source-build fallback covers it; revisit on demand)

--- a/nfpm-cagebreak.yaml
+++ b/nfpm-cagebreak.yaml
@@ -1,0 +1,24 @@
+# nfpm config for cagebreak packages built by .github/workflows/release.yml.
+# Packages the compositor binary only — sysc-greet itself ships via nfpm.yaml.
+# CAGEBREAK_VERSION is the cagebreak tag, not the sysc-greet version.
+# The release workflow appends per-distro runtime depends as list items under
+# the trailing `depends:` key, so `depends:` must stay the last key here.
+name: cagebreak
+arch: amd64
+platform: linux
+version: ${CAGEBREAK_VERSION}
+release: "1"
+section: x11
+priority: optional
+maintainer: Nomadcxx <noovie@gmail.com>
+description: |
+  Cagebreak Wayland compositor.
+  Built from https://github.com/project-repo/cagebreak against this
+  distribution's wlroots for use as the sysc-greet greeter compositor.
+vendor: project-repo
+homepage: https://github.com/project-repo/cagebreak
+license: MIT
+contents:
+  - src: ./cagebreak/build/cagebreak
+    dst: /usr/bin/cagebreak
+depends:


### PR DESCRIPTION
Ships cagebreak on Debian/Ubuntu/Fedora, where it has no distro package. Unblocks hyprland greeter removal on apt/dnf distros. Follows #78.

Plan: `docs/superpowers/plans/2026-07-06-cagebreak-distro-packaging-plan.md`

## What this does

1. **Release CI builds cagebreak per distro.** New `package-cagebreak` matrix job in `release.yml` builds cagebreak in distro containers against each distro's wlroots, smoke-tests it headless against the greeter config, packages it with nfpm (`nfpm-cagebreak.yaml`), and attaches the packages to releases.
2. **Installer installs it.** On apt/dnf the installer downloads the matching release artifact (`/etc/os-release` mapping) and falls back to `buildCagebreakFromSource` (wlroots pkg-config probe → buildable tag). zypper uses Tumbleweed's package. The compositor selection screen no longer blocks on missing cagebreak, and `socat` is now installed on every cagebreak path (it was missing even on Arch).

## Key constraint

Cagebreak pins wlroots per tag with no meson subproject fallback, so the distro's wlroots dictates the tag:

| Target | wlroots | cagebreak | artifact |
|---|---|---|---|
| ubuntu:24.04 | 0.17.1 | 2.3.1 | `cagebreak_2.3.1_ubuntu24.04_amd64.deb` |
| debian:13 (also Ubuntu 25.x) | 0.18.2 | 2.4.0 | `cagebreak_2.4.0_debian13_amd64.deb` |
| fedora:42 | 0.19.2 | 3.1.0 | `cagebreak-3.1.0-1.fedora42.x86_64.rpm` |
| wlroots 0.20 distros | 0.20.1 | 3.2.1 | source build |

## Validated locally (docker)

- All three targets: deps install, build, headless smoke test pass (`Cagebreak version` prints, config parses, compositor runs until timeout)
- Runtime depends derived empirically via `objdump`/`ldd` + `dpkg -S`/`rpm -qf` in each container (Ubuntu 24.04's wlroots is `libwlroots12t64` — not guessable)
- deb `Depends` and rpm `Requires` verified on built packages; fedora rpm requires `libwlroots-0.19.so()(64bit)` so dnf refuses on Fedora 43+ instead of installing a broken binary
- Ubuntu 25.04 confirmed to carry the debian13 artifact's dependency names
- Found in validation: cagebreak refuses to start as root — CI smoke test runs as an unprivileged user

## Remaining before merge

- [ ] `workflow_dispatch` dry-run of the release workflow
- [ ] Phase C container validation: installer end-to-end on debian:13 / ubuntu:24.04 / fedora:42
- [ ] First real artifacts appear on the next tagged release (installer falls back to source build until then)
