### PR TITLE
fix: remove kitty opacity rule from niri greeter config

### DIFF
--- a/cmd/installer/main.go
+++ b/cmd/installer/main.go
@@ -1531,11 +1531,6 @@ animations {
     off
 }
 
-window-rule {
-    match app-id="kitty"
-    opacity 0.90
-}
-
 spawn-sh-at-startup "HOME=/var/lib/greeter /usr/local/bin/sysc-greet --wallpaper-daemon"
 
 spawn-sh-at-startup "XDG_CACHE_HOME=/tmp/greeter-cache HOME=/var/lib/greeter kitty --start-as=fullscreen --config=/etc/greetd/kitty.conf /usr/local/bin/sysc-greet; niri msg action quit --skip-confirmation"

--- a/config/niri-greeter-config.kdl
+++ b/config/niri-greeter-config.kdl
@@ -65,11 +65,6 @@ animations {
     off
 }
 
-window-rule {
-    match app-id="kitty"
-    opacity 0.90
-}
-
 // Start gslapper with the cached greeter wallpaper (forked to background with IPC socket)
 spawn-sh-at-startup "HOME=/var/lib/greeter /usr/local/bin/sysc-greet --wallpaper-daemon"
 


### PR DESCRIPTION
Wallpapers serve secondary monitors; the greeter TUI draws its own background and stays fully opaque. The 0.90 window-rule made the TUI translucent for no purpose. Removed from the shipped niri config and the installer's embedded copy.