### PR TITLE
perf: idle-gate tick chains and run-length effect rendering

### DIFF
--- a/cmd/installer/main.go
+++ b/cmd/installer/main.go
@@ -1705,14 +1705,24 @@ func installConfigs(m *model) error {
 }
 
 func setupCache(m *model) error {
-	// Create cache directory
-	if err := exec.Command("mkdir", "-p", "/var/cache/sysc-greet").Run(); err != nil {
-		return fmt.Errorf("cache dir creation failed")
+	// Create greeter-owned state/cache directories used by kitty, gSlapper,
+	// shader caches, and sysc-greet preferences.
+	dirs := []string{
+		"/var/cache/sysc-greet",
+		"/var/lib/greeter/Pictures/wallpapers",
+		"/var/lib/greeter/.cache",
+		"/var/lib/greeter/.config",
+		"/var/lib/greeter/.local/state",
+		"/tmp/greeter-cache",
+	}
+	for _, dir := range dirs {
+		if err := exec.Command("mkdir", "-p", dir).Run(); err != nil {
+			return fmt.Errorf("directory creation failed for %s", dir)
+		}
 	}
 
-	// Create greeter home
-	if err := exec.Command("mkdir", "-p", "/var/lib/greeter/Pictures/wallpapers").Run(); err != nil {
-		return fmt.Errorf("greeter home creation failed")
+	if err := exec.Command("chmod", "755", "/var/lib/greeter").Run(); err != nil {
+		return fmt.Errorf("permissions change failed")
 	}
 
 	// Create greeter user if needed
@@ -1722,27 +1732,24 @@ func setupCache(m *model) error {
 	cmd := exec.Command("id", "greeter")
 	if err := cmd.Run(); err != nil {
 		// User doesn't exist - create with video,render,input groups
-		cmd = exec.Command("useradd", "-M", "-G", "video,render,input", "-s", "/usr/bin/nologin", "greeter")
+		cmd = exec.Command("useradd", "-M", "-d", "/var/lib/greeter", "-G", "video,render,input", "-s", "/usr/bin/nologin", "greeter")
 		if err := cmd.Run(); err != nil {
 			return fmt.Errorf("greeter user creation failed")
 		}
 	} else {
-		// User exists - ensure they have required groups
+		// User exists - ensure they have required groups and a writable home.
 		// CRITICAL: This fixes laptops where greeter user exists but lacks render group
-		exec.Command("usermod", "-aG", "video,render,input", "greeter").Run()
+		if err := exec.Command("usermod", "-d", "/var/lib/greeter", "-aG", "video,render,input", "greeter").Run(); err != nil {
+			return fmt.Errorf("greeter user update failed")
+		}
 	}
 
 	// Set ownership
-	paths := []string{"/var/cache/sysc-greet", "/var/lib/greeter"}
+	paths := []string{"/var/cache/sysc-greet", "/var/lib/greeter", "/tmp/greeter-cache"}
 	for _, path := range paths {
 		if err := exec.Command("chown", "-R", "greeter:greeter", path).Run(); err != nil {
 			return fmt.Errorf("ownership change failed for %s", path)
 		}
-	}
-
-	// Set permissions
-	if err := exec.Command("chmod", "755", "/var/lib/greeter").Run(); err != nil {
-		return fmt.Errorf("permissions change failed")
 	}
 
 	return nil
@@ -1798,9 +1805,9 @@ animations {
     off
 }
 
-spawn-sh-at-startup "HOME=/var/lib/greeter /usr/local/bin/sysc-greet --wallpaper-daemon"
+spawn-sh-at-startup "cd /var/lib/greeter && env HOME=/var/lib/greeter XDG_CACHE_HOME=/var/lib/greeter/.cache XDG_CONFIG_HOME=/var/lib/greeter/.config XDG_STATE_HOME=/var/lib/greeter/.local/state /usr/local/bin/sysc-greet --wallpaper-daemon"
 
-spawn-sh-at-startup "XDG_CACHE_HOME=/tmp/greeter-cache HOME=/var/lib/greeter kitty --start-as=fullscreen --config=/etc/greetd/kitty.conf /usr/local/bin/sysc-greet; niri msg action quit --skip-confirmation"
+spawn-sh-at-startup "cd /var/lib/greeter && env HOME=/var/lib/greeter XDG_CACHE_HOME=/var/lib/greeter/.cache XDG_CONFIG_HOME=/var/lib/greeter/.config XDG_STATE_HOME=/var/lib/greeter/.local/state kitty --start-as=fullscreen --config=/etc/greetd/kitty.conf /usr/local/bin/sysc-greet; niri msg action quit --skip-confirmation"
 
 binds {
 }
@@ -1868,8 +1875,8 @@ windowrule = match:class ^(kitty)$, fullscreen on, opacity 1.0
 layerrule = match:namespace wallpaper, blur on
 
 # Startup applications
-exec-once = HOME=/var/lib/greeter /usr/local/bin/sysc-greet --wallpaper-daemon
-exec-once = XDG_CACHE_HOME=/tmp/greeter-cache HOME=/var/lib/greeter kitty --start-as=fullscreen --config=/etc/greetd/kitty.conf /usr/local/bin/sysc-greet && hyprctl dispatch exit
+exec-once = cd /var/lib/greeter && env HOME=/var/lib/greeter XDG_CACHE_HOME=/var/lib/greeter/.cache XDG_CONFIG_HOME=/var/lib/greeter/.config XDG_STATE_HOME=/var/lib/greeter/.local/state /usr/local/bin/sysc-greet --wallpaper-daemon
+exec-once = cd /var/lib/greeter && env HOME=/var/lib/greeter XDG_CACHE_HOME=/var/lib/greeter/.cache XDG_CONFIG_HOME=/var/lib/greeter/.config XDG_STATE_HOME=/var/lib/greeter/.local/state kitty --start-as=fullscreen --config=/etc/greetd/kitty.conf /usr/local/bin/sysc-greet && hyprctl dispatch exit
 `
 		configPath = "/etc/greetd/hyprland-greeter-config.conf"
 		greetdCommand = "start-hyprland -- -c /etc/greetd/hyprland-greeter-config.conf"
@@ -1903,8 +1910,8 @@ input type:touchpad {
 for_window [app_id="kitty"] fullscreen enable
 
 # Startup applications
-exec "HOME=/var/lib/greeter /usr/local/bin/sysc-greet --wallpaper-daemon"
-exec "XDG_CACHE_HOME=/tmp/greeter-cache HOME=/var/lib/greeter kitty --start-as=fullscreen --config=/etc/greetd/kitty.conf /usr/local/bin/sysc-greet; swaymsg exit"
+exec "cd /var/lib/greeter && env HOME=/var/lib/greeter XDG_CACHE_HOME=/var/lib/greeter/.cache XDG_CONFIG_HOME=/var/lib/greeter/.config XDG_STATE_HOME=/var/lib/greeter/.local/state /usr/local/bin/sysc-greet --wallpaper-daemon"
+exec "cd /var/lib/greeter && env HOME=/var/lib/greeter XDG_CACHE_HOME=/var/lib/greeter/.cache XDG_CONFIG_HOME=/var/lib/greeter/.config XDG_STATE_HOME=/var/lib/greeter/.local/state kitty --start-as=fullscreen --config=/etc/greetd/kitty.conf /usr/local/bin/sysc-greet; swaymsg exit"
 `
 		configPath = "/etc/greetd/sway-greeter-config"
 		greetdCommand = "sway --unsupported-gpu -c /etc/greetd/sway-greeter-config"
@@ -1918,10 +1925,10 @@ exec "XDG_CACHE_HOME=/tmp/greeter-cache HOME=/var/lib/greeter kitty --start-as=f
 background 0.0 0.0 0.0
 
 # gSlapper wallpaper daemon (wlr-layer-shell client, same as niri/sway setup)
-exec HOME=/var/lib/greeter /usr/local/bin/sysc-greet --wallpaper-daemon
+exec cd /var/lib/greeter && env HOME=/var/lib/greeter XDG_CACHE_HOME=/var/lib/greeter/.cache XDG_CONFIG_HOME=/var/lib/greeter/.config XDG_STATE_HOME=/var/lib/greeter/.local/state /usr/local/bin/sysc-greet --wallpaper-daemon
 
 # Greeter UI; when it exits (login or shutdown), quit cagebreak so greetd can start the session
-exec XDG_CACHE_HOME=/tmp/greeter-cache HOME=/var/lib/greeter kitty --start-as=fullscreen --config=/etc/greetd/kitty.conf /usr/local/bin/sysc-greet; echo quit | socat - UNIX-CONNECT:"$CAGEBREAK_SOCKET"
+exec cd /var/lib/greeter && env HOME=/var/lib/greeter XDG_CACHE_HOME=/var/lib/greeter/.cache XDG_CONFIG_HOME=/var/lib/greeter/.config XDG_STATE_HOME=/var/lib/greeter/.local/state kitty --start-as=fullscreen --config=/etc/greetd/kitty.conf /usr/local/bin/sysc-greet; echo quit | socat - UNIX-CONNECT:"$CAGEBREAK_SOCKET"
 
 # No bind/definekey lines on purpose: no compositor keybindings reachable from the greeter
 `

--- a/cmd/sysc-greet/main.go
+++ b/cmd/sysc-greet/main.go
@@ -44,20 +44,20 @@ var debugLog *log.Logger
 func initDebugLog() {
 	// Try persistent location first ($HOME/.cache/sysc-greet/debug.log)
 	// Falls back to /tmp/ if home dir unavailable
-	logPath := "/tmp/sysc-greet-debug.log"
+	logPaths := []string{"/tmp/sysc-greet-debug.log"}
 	if home, err := os.UserHomeDir(); err == nil {
 		cacheDir := filepath.Join(home, ".cache", "sysc-greet")
 		os.MkdirAll(cacheDir, 0755)
-		logPath = filepath.Join(cacheDir, "debug.log")
+		logPaths = append([]string{filepath.Join(cacheDir, "debug.log")}, logPaths...)
 	}
 
-	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
-	if err != nil {
-		// Fallback to stderr if can't open log file
-		debugLog = log.New(os.Stderr, "[DEBUG] ", log.Ldate|log.Ltime|log.Lshortfile)
-		return
+	for _, logPath := range logPaths {
+		logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+		if err == nil {
+			debugLog = log.New(logFile, "[DEBUG] ", log.Ldate|log.Ltime|log.Lshortfile)
+			return
+		}
 	}
-	debugLog = log.New(logFile, "[DEBUG] ", log.Ldate|log.Ltime|log.Lshortfile)
 }
 
 func logDebug(format string, args ...interface{}) {
@@ -549,7 +549,7 @@ func initialModel(config Config, screensaverMode bool) model {
 	if config.Debug {
 		logDebug(" Loaded %d sessions", len(sess))
 		for _, s := range sess {
-			fmt.Printf("  - %s (%s)\n", s.Name, s.Type)
+			logDebug("  - %s (%s)", s.Name, s.Type)
 		}
 	}
 
@@ -1280,7 +1280,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		if m.config.Debug {
 			// Log ALL key presses to debug what modifiers are being sent
-			fmt.Fprintf(os.Stderr, "KEY: %q | Mod=%08b (%d) | CapsLock=%v\n",
+			logDebug("KEY: %q | Mod=%08b (%d) | CapsLock=%v",
 				key.Text, key.Mod, key.Mod, m.capsLockOn)
 		}
 
@@ -1341,7 +1341,7 @@ func (m model) handleKeyInput(msg tea.KeyMsg) (model, tea.Cmd) {
 	// Updated for tea.KeyMsg v2 API
 	if m.config.Debug {
 		keyStr := msg.String()
-		fmt.Fprintf(os.Stderr, "KEY DEBUG: String='%s'\n", keyStr)
+		logDebug("KEY DEBUG: String='%s'", keyStr)
 	}
 
 	switch msg.String() {
@@ -1388,7 +1388,7 @@ func (m model) handleKeyInput(msg tea.KeyMsg) (model, tea.Cmd) {
 		// Release notes popup - works from any mode
 		m.sessionDropdownOpen = false
 		if m.config.Debug {
-			fmt.Println("Debug: Opening release notes")
+			logDebug("Opening release notes")
 		}
 		m.mode = ModeReleaseNotes
 		m.usernameInput.Blur()
@@ -1401,7 +1401,7 @@ func (m model) handleKeyInput(msg tea.KeyMsg) (model, tea.Cmd) {
 		m.sessionDropdownOpen = false
 		m.powerIndex = 0
 		if m.config.Debug {
-			fmt.Println("Debug: Opening power menu")
+			logDebug("Opening power menu")
 		}
 		m.mode = ModePower
 		m.usernameInput.Blur()
@@ -2400,7 +2400,7 @@ func (m model) handleKeyInput(msg tea.KeyMsg) (model, tea.Cmd) {
 			} else {
 				// Enter from username goes to password
 				if m.config.Debug {
-					fmt.Println("Debug: Switching to password mode")
+					logDebug("Switching to password mode")
 				}
 				m.mode = ModePassword
 				m.focusState = FocusPassword
@@ -2921,11 +2921,6 @@ func main() {
 	logDebug("GREETD_SOCK: %s", os.Getenv("GREETD_SOCK"))
 	logDebug("WAYLAND_DISPLAY: %s", os.Getenv("WAYLAND_DISPLAY"))
 	logDebug("XDG_RUNTIME_DIR: %s", os.Getenv("XDG_RUNTIME_DIR"))
-
-	if config.Debug {
-		fmt.Printf("Debug mode enabled\n")
-		fmt.Printf("Debug log: /tmp/sysc-greet-debug.log\n")
-	}
 
 	// Initialize Bubble Tea program with proper screen management
 	// CHANGED 2025-09-29 - Handle TTY access gracefully for different environments

--- a/cmd/sysc-greet/main.go
+++ b/cmd/sysc-greet/main.go
@@ -414,6 +414,51 @@ func doTick() tea.Cmd {
 	})
 }
 
+// doSlowTick keeps the UI tick chain alive at 1s while nothing on screen
+// animates: enough for the screensaver idle check and clock. One chain only —
+// see doBgTickIdle for why extra chains are forbidden.
+func doSlowTick() tea.Cmd {
+	return tea.Tick(time.Second, func(t time.Time) tea.Msg {
+		return tickMsg(t)
+	})
+}
+
+// uiAnimationsActive reports whether anything on screen needs the fast 30ms
+// UI tick right now. When false, the tick drops to 1s and the animation
+// counters freeze (a frozen banner gradient beats one stepping at 1fps).
+func (m model) uiAnimationsActive() bool {
+	// Someone is at the keyboard: keep everything smooth
+	if time.Since(m.idleTimer) < time.Minute {
+		return true
+	}
+	// Wall-clock driven animations visible on the login screens
+	if m.mode == ModeLogin || m.mode == ModePassword {
+		switch m.selectedBackground {
+		case "ticker", "print", "beams", "pour":
+			return true
+		}
+	}
+	// Screensaver print animation in progress
+	if m.mode == ModeScreensaver && m.screensaverPrint != nil && !m.screensaverPrint.IsComplete() {
+		return true
+	}
+	// Lazy inits ride this tick (0d1299c); stay fast until they have fired
+	if !m.gslapperLaunched && m.selectedWallpaper != "" {
+		return true
+	}
+	switch m.selectedBackground {
+	case "aquarium":
+		return m.aquariumEffect == nil
+	case "sonar":
+		return m.sonarEffect == nil
+	case "cracktro":
+		return m.cracktroEffect == nil
+	case "plasma":
+		return m.plasmaEffect == nil
+	}
+	return false
+}
+
 type bgTickMsg time.Time
 
 func doBgTick(speed string) tea.Cmd {
@@ -895,9 +940,14 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case tickMsg:
-		m.animationFrame++
-		m.pulseColor = (m.pulseColor + 1) % 100
-		m.borderFrame = (m.borderFrame + 1) % 20
+		fastTick := m.uiAnimationsActive()
+		if fastTick {
+			// Counters only advance on fast ticks so idle frames are
+			// byte-identical and the renderer diffs them to nothing
+			m.animationFrame++
+			m.pulseColor = (m.pulseColor + 1) % 100
+			m.borderFrame = (m.borderFrame + 1) % 20
+		}
 
 		// Lazy init: create aquarium on first tick when we have real dimensions
 		if m.selectedBackground == "aquarium" && m.aquariumEffect == nil && m.width > 0 && m.height > 0 {
@@ -990,7 +1040,11 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.pourEffect.Update()
 		}
 
-		cmds = append(cmds, doTick())
+		if fastTick {
+			cmds = append(cmds, doTick())
+		} else {
+			cmds = append(cmds, doSlowTick())
+		}
 
 	case bgTickMsg:
 		if !m.backgroundEffectActive() {

--- a/cmd/sysc-greet/main.go
+++ b/cmd/sysc-greet/main.go
@@ -378,6 +378,8 @@ type model struct {
 	screensaverTime   time.Time               // Current time for screensaver display
 	screensaverPrint  *animations.PrintEffect // CHANGED 2025-10-11 - Print effect animation for screensaver
 	screensaverActive bool                    // CHANGED 2025-10-11 - Track if screensaver just activated
+	ssConfig          ScreensaverConfig       // Cached screensaver.conf; reading it per tick was 33 file opens/s
+	ssConfigLoaded    time.Time               // Last cache refresh (refreshed at most every 60s from the tick handler)
 
 	// ASCII navigation fields for multi-variant support
 	asciiArtIndex      int         // Current variant index (0-indexed)
@@ -609,6 +611,8 @@ func initialModel(config Config, screensaverMode bool) model {
 		// CHANGED 2025-10-10 - Initialize screensaver timers
 		idleTimer:       time.Now(),
 		screensaverTime: time.Now(),
+		ssConfig:        loadScreensaverConfig(),
+		ssConfigLoaded:  time.Now(),
 		// Initialize fire effect with default size
 		fireEffect: animations.NewFireEffect(80, 30, animations.GetDefaultFirePalette()),
 		// CHANGED 2025-10-08 - Initialize rain effect with default size
@@ -791,7 +795,7 @@ func initialModel(config Config, screensaverMode bool) model {
 
 	// CHANGED 2025-10-11 - Initialize print effect if starting in screensaver mode
 	if screensaverMode {
-		ssConfig := loadScreensaverConfig()
+		ssConfig := m.ssConfig
 		if ssConfig.AnimateOnStart && ssConfig.AnimationType == "print" && len(ssConfig.ASCIIVariants) > 0 {
 			selectedASCII := ssConfig.ASCIIVariants[0]
 			charDelay := time.Duration(ssConfig.AnimationSpeed) * time.Millisecond
@@ -920,9 +924,16 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.screensaverPrint.Tick(m.screensaverTime)
 		}
 
+		// Refresh the cached screensaver config at most once a minute so edits
+		// to screensaver.conf still apply without restarting the greeter
+		if time.Since(m.ssConfigLoaded) > time.Minute {
+			m.ssConfig = loadScreensaverConfig()
+			m.ssConfigLoaded = time.Now()
+		}
+
 		// Check for screensaver activation using configurable timeout
 		if m.mode == ModeLogin || m.mode == ModePassword {
-			ssConfig := loadScreensaverConfig()
+			ssConfig := m.ssConfig
 			idleDuration := time.Since(m.idleTimer)
 			if idleDuration >= time.Duration(ssConfig.IdleTimeout)*time.Minute && m.mode != ModeScreensaver {
 				m.mode = ModeScreensaver

--- a/cmd/sysc-greet/main.go
+++ b/cmd/sysc-greet/main.go
@@ -429,6 +429,32 @@ func doBgTick(speed string) tea.Cmd {
 	})
 }
 
+// doBgTickIdle keeps the background tick chain alive on a slow heartbeat while
+// no effect is animating. One chain only — spawning extra chains on events
+// multiplies the frame rate (the "hyperspeed" bug class, issue #45).
+func doBgTickIdle() tea.Cmd {
+	return tea.Tick(250*time.Millisecond, func(t time.Time) tea.Msg {
+		return bgTickMsg(t)
+	})
+}
+
+// backgroundEffectActive reports whether the selected background needs
+// per-frame bgTick updates right now. Effects only display on the login and
+// password screens (see View), so other modes don't pay for animation.
+func (m model) backgroundEffectActive() bool {
+	if m.mode != ModeLogin && m.mode != ModePassword {
+		return false
+	}
+	if m.enableFire {
+		return true
+	}
+	switch m.selectedBackground {
+	case "fire", "fire+rain", "ascii-rain", "matrix", "fireworks", "sonar", "cracktro", "plasma", "aquarium":
+		return true
+	}
+	return false
+}
+
 // cycleAnimSpeed cycles to the next speed preset
 func cycleAnimSpeed(current string) string {
 	switch current {
@@ -967,6 +993,11 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		cmds = append(cmds, doTick())
 
 	case bgTickMsg:
+		if !m.backgroundEffectActive() {
+			cmds = append(cmds, doBgTickIdle())
+			return m, tea.Batch(cmds...)
+		}
+
 		m.bgAnimationFrame++
 
 		if (m.enableFire || m.selectedBackground == "fire" || m.selectedBackground == "fire+rain") && m.fireEffect != nil {

--- a/cmd/sysc-greet/main.go
+++ b/cmd/sysc-greet/main.go
@@ -704,6 +704,14 @@ func initialModel(config Config, screensaverMode bool) model {
 		typewriterTicker: nil,
 	}
 
+	// Test mode skips cached preferences, so SYSC_BG lets a background effect
+	// be exercised directly: SYSC_BG=fire sysc-greet --test
+	if config.TestMode {
+		if bg := os.Getenv("SYSC_BG"); bg != "" {
+			m.selectedBackground = bg
+		}
+	}
+
 	// CHANGED 2025-10-03 - Load cached preferences including session
 	// CHANGED 2025-10-03 - Skip cache in test mode
 	// FIXED 2025-10-17 - Apply Dracula as fallback if no cached theme exists

--- a/cmd/sysc-greet/main.go
+++ b/cmd/sysc-greet/main.go
@@ -1280,8 +1280,12 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		if m.config.Debug {
 			// Log ALL key presses to debug what modifiers are being sent
+			keyText := key.Text
+			if m.passwordInputActive() {
+				keyText = "<redacted>"
+			}
 			logDebug("KEY: %q | Mod=%08b (%d) | CapsLock=%v",
-				key.Text, key.Mod, key.Mod, m.capsLockOn)
+				keyText, key.Mod, key.Mod, m.capsLockOn)
 		}
 
 		// CHANGED 2025-10-12 - Handle screensaver exit on any key press
@@ -1341,6 +1345,9 @@ func (m model) handleKeyInput(msg tea.KeyMsg) (model, tea.Cmd) {
 	// Updated for tea.KeyMsg v2 API
 	if m.config.Debug {
 		keyStr := msg.String()
+		if m.passwordInputActive() {
+			keyStr = "<redacted>"
+		}
 		logDebug("KEY DEBUG: String='%s'", keyStr)
 	}
 
@@ -2445,6 +2452,10 @@ func (m model) handleKeyInput(msg tea.KeyMsg) (model, tea.Cmd) {
 	}
 
 	return m, nil
+}
+
+func (m model) passwordInputActive() bool {
+	return m.mode == ModePassword && m.focusState == FocusPassword
 }
 
 // Return tea.View with BackgroundColor set

--- a/cmd/sysc-greet/screensaver.go
+++ b/cmd/sysc-greet/screensaver.go
@@ -191,7 +191,7 @@ func renderStyledClock(timeStr string, style string) []string {
 
 // renderScreensaverView renders the screensaver with ASCII art, clock, and date
 func renderScreensaverView(m model, termWidth, termHeight int) string {
-	config := loadScreensaverConfig()
+	config := m.ssConfig
 
 	// Get theme-specific color palette
 	palette := animations.GetScreensaverPalette(m.currentTheme)

--- a/config/cagebreak-greeter-config
+++ b/config/cagebreak-greeter-config
@@ -6,9 +6,9 @@
 background 0.0 0.0 0.0
 
 # gSlapper wallpaper daemon (wlr-layer-shell client, same as niri/sway setup)
-exec HOME=/var/lib/greeter /usr/local/bin/sysc-greet --wallpaper-daemon
+exec cd /var/lib/greeter && env HOME=/var/lib/greeter XDG_CACHE_HOME=/var/lib/greeter/.cache XDG_CONFIG_HOME=/var/lib/greeter/.config XDG_STATE_HOME=/var/lib/greeter/.local/state /usr/local/bin/sysc-greet --wallpaper-daemon
 
 # Greeter UI; when it exits (login or shutdown), quit cagebreak so greetd can start the session
-exec XDG_CACHE_HOME=/tmp/greeter-cache HOME=/var/lib/greeter kitty --start-as=fullscreen --config=/etc/greetd/kitty.conf /usr/local/bin/sysc-greet; echo quit | socat - UNIX-CONNECT:"$CAGEBREAK_SOCKET"
+exec cd /var/lib/greeter && env HOME=/var/lib/greeter XDG_CACHE_HOME=/var/lib/greeter/.cache XDG_CONFIG_HOME=/var/lib/greeter/.config XDG_STATE_HOME=/var/lib/greeter/.local/state kitty --start-as=fullscreen --config=/etc/greetd/kitty.conf /usr/local/bin/sysc-greet; echo quit | socat - UNIX-CONNECT:"$CAGEBREAK_SOCKET"
 
 # No bind/definekey lines on purpose: no compositor keybindings reachable from the greeter

--- a/docs/superpowers/plans/2026-07-07-perf-render-loop-plan.md
+++ b/docs/superpowers/plans/2026-07-07-perf-render-loop-plan.md
@@ -1,12 +1,29 @@
 # Render Loop Performance — Plan
 
-> **Status:** Implemented; awaiting visual verification on real kitty
+> **Status:** Implemented; verified on real greetd + cagebreak + kitty
 > **Results (240x67 pty):** idle 53% → 31% active / **5.9% after 60s idle**;
 > fire 84% → 44%; matrix 60% → 44%; plasma 77% → 69%. Fire render
 > 5.3ms/24,459 allocs → 0.13ms/3 allocs per frame.
 > **Spec:** [2026-07-07 perf audit](../audits/2026-07-07-perf-audit.md)
 > **Branch:** `perf/render-loop` (worktree-isolated; merge target `development`)
 > **Baseline (240x67 pty):** idle 53% CPU / 1.0 MiB/s output; fire 84%; plasma 77%
+
+## Real-greeter verification notes
+
+Nomadcxx tested the branch on a laptop through the real greetd + cagebreak
+path. Login succeeded after fixing cagebreak's greeter environment, and the
+sampled background effects looked visually correct. The test surfaced two
+non-render regressions that are fixed in this branch:
+
+- **Greeter home/XDG environment:** uninstall/reinstall regenerated the new
+  cagebreak config while the `greeter` account still had `/home/greeter` as
+  its passwd home. gSlapper/GLFW then tried shader/cache writes under
+  `/home/greeter`. The installer, postinstall script, and cagebreak config now
+  force `/var/lib/greeter` as home/cwd and set writable XDG cache/config/state
+  directories for greeter child processes.
+- **Debug output and TUI corruption:** `--debug` still had direct stdout/stderr
+  writes in key/menu paths, so debug mode could draw over the Bubble Tea UI in
+  production. Debug-only chatter now goes through the file logger.
 
 ## Regression constraints (from git history)
 
@@ -91,9 +108,10 @@ colored until restart. Self-healing beats the micro-win. Not done on purpose.
   record in the PR body against the baseline table
 - Effect output invariants test: every Render() row = exactly `width` cells,
   `height` rows, row-end reset — added as a real test in this PR
-- Visual check on real kitty by Nomadcxx before merge (gradients, ticker
-  smoothness, menu responsiveness, screensaver entry/exit, power menu
-  ghosting)
+- Visual check on real kitty/greetd by Nomadcxx before merge (gradients,
+  ticker smoothness, menu responsiveness, screensaver entry/exit, power menu
+  ghosting). Initial real-greeter pass succeeded for login and sampled effects;
+  rerun once after the debug-output cleanup.
 
 ## Out of scope
 

--- a/docs/superpowers/plans/2026-07-07-perf-render-loop-plan.md
+++ b/docs/superpowers/plans/2026-07-07-perf-render-loop-plan.md
@@ -1,0 +1,98 @@
+# Render Loop Performance — Plan
+
+> **Status:** In progress
+> **Spec:** [2026-07-07 perf audit](../audits/2026-07-07-perf-audit.md)
+> **Branch:** `perf/render-loop` (worktree-isolated; merge target `development`)
+> **Baseline (240x67 pty):** idle 53% CPU / 1.0 MiB/s output; fire 84%; plasma 77%
+
+## Regression constraints (from git history)
+
+These shaped the current code; violating them re-opens closed bugs:
+
+1. **View() and all render functions stay pure** — no `Update()`, `Resize()`,
+   or any state mutation from render paths. Value-receiver mutation from View
+   caused the "hyperspeed on first boot" bug (7e1c316, issue #45). All
+   changes here live in `Update()` handlers and tick scheduling.
+2. **The dual tick chain is intentional.** `bgTickMsg` exists so animSpeed
+   (slow 60ms / normal 30ms / fast 15ms) only affects background effects
+   (ff8ca52, c5bfb7e). The 30ms UI tick was picked for typewriter-ticker
+   smoothness (a02cb history note in main.go:409). Both features must behave
+   identically when animations are active.
+3. **Ghosting protections stay intact.** The full-terminal blank backing layer
+   (e265c41) and full-width effect rows are load-bearing: every effect Render()
+   row must remain exactly `width` visible cells, and `render_test.go` must
+   pass. Rows end with an SGR reset so colors can't bleed into padding.
+4. **Lazy inits ride the tick** (0d1299c, 6f5ab3f): aquarium/sonar/cracktro/
+   plasma creation and the gslapper launch happen on tickMsg once dimensions
+   are known. Tick gating must not run before these have fired.
+
+## Changes
+
+### 1. Cache screensaver config (main.go:925, screensaver.go)
+
+`loadScreensaverConfig()` opens and parses screensaver.conf on every 30ms tick.
+Cache it in the model at startup; refresh at most once per 60s from the tick
+handler (preserves live-edit of idle_timeout without the 33/s file opens).
+
+### 2. Skip bgTick work when nothing is animating
+
+`doBgTick` reschedules at full rate with background "none". Keep the chain
+alive (self-healing, avoids kick-on-every-selection-path bugs) but reschedule
+at 1s when no effect is selected or the mode can't display it. On background
+selection in the menu, the key-event handler kicks an immediate fast bgTick so
+switching feels instant.
+
+### 3. Idle-gate the UI tick
+
+The 30ms tick drives: typewriter ticker, banner gradient, border animation
+counters, screensaver idle check, print/beams/pour effects, lazy inits.
+Adaptive interval, decided in the tickMsg handler:
+
+- **30ms (unchanged):** any of — last key input < 60s ago; ticker background
+  selected; print/beams/pour active; screensaver print animation running;
+  lazy inits still pending.
+- **1s:** otherwise (idle at login, screensaver clock). Animation counters
+  (`animationFrame`, `borderFrame`, `pulseColor`) do NOT advance on slow
+  ticks — the banner gradient freezes instead of stepping at 1fps. Screensaver
+  activation and clock only need 1s resolution.
+- Any key press returns to 30ms immediately (key handler already reschedules
+  the chain implicitly — verify; if not, kick one).
+
+### 4. Run-length SGR rendering in effect Render() methods
+
+Replace per-cell `lipgloss.NewStyle().Foreground().Render()` with direct SGR
+writing: single `strings.Builder` grown upfront, emit `38;2;r;g;bm` only when
+the cell color differs from the previous cell, reset at each row end. Prototype
+benched 39x on fire (5.3ms → 0.13ms, 24,459 → 3 allocs).
+
+Safety: layer content is parsed into cells by ultraviolet
+(`StyledString.Draw`), and the terminal writer re-emits per the detected color
+profile — raw truecolor SGR in layer content does not bypass TTY fallback.
+Verify by inspecting emitted output under `TERM=linux`.
+
+Effects, in order: fire, matrix, rain (shared helper), then plasma, aquarium,
+fireworks, beams, beams_text, pour, blackhole, print as applicable — audit each
+for the same pattern before converting.
+
+### 5. Palette updates on theme change only
+
+Move `UpdatePalette(GetXPalette(theme))` calls out of the bgTick handler into
+the theme-selection handler. (Micro, but it's free while in there.)
+
+## Verification per step
+
+- `go test ./...` (render_test.go guards layer alignment)
+- Effect benchmarks before/after (`audit_bench_test.go` pattern)
+- pty CPU measurement (ptyrun harness): idle, fire, matrix, plasma —
+  record in the PR body against the baseline table
+- Effect output invariants test: every Render() row = exactly `width` cells,
+  `height` rows, row-end reset — added as a real test in this PR
+- Visual check on real kitty by Nomadcxx before merge (gradients, ticker
+  smoothness, menu responsiveness, screensaver entry/exit, power menu
+  ghosting)
+
+## Out of scope
+
+- Plasma's 111 MiB RSS (separate issue if it survives the render rewrite)
+- bubbletea/ultraviolet-level optimizations
+- Any visual redesign; output must look identical at active frame rates

--- a/docs/superpowers/plans/2026-07-07-perf-render-loop-plan.md
+++ b/docs/superpowers/plans/2026-07-07-perf-render-loop-plan.md
@@ -1,6 +1,9 @@
 # Render Loop Performance — Plan
 
-> **Status:** In progress
+> **Status:** Implemented; awaiting visual verification on real kitty
+> **Results (240x67 pty):** idle 53% → 31% active / **5.9% after 60s idle**;
+> fire 84% → 44%; matrix 60% → 44%; plasma 77% → 69%. Fire render
+> 5.3ms/24,459 allocs → 0.13ms/3 allocs per frame.
 > **Spec:** [2026-07-07 perf audit](../audits/2026-07-07-perf-audit.md)
 > **Branch:** `perf/render-loop` (worktree-isolated; merge target `development`)
 > **Baseline (240x67 pty):** idle 53% CPU / 1.0 MiB/s output; fire 84%; plasma 77%
@@ -74,10 +77,11 @@ Effects, in order: fire, matrix, rain (shared helper), then plasma, aquarium,
 fireworks, beams, beams_text, pour, blackhole, print as applicable — audit each
 for the same pattern before converting.
 
-### 5. Palette updates on theme change only
+### 5. Palette updates on theme change only — DROPPED
 
-Move `UpdatePalette(GetXPalette(theme))` calls out of the bgTick handler into
-the theme-selection handler. (Micro, but it's free while in there.)
+The per-tick palette sync costs ~2μs/frame; moving it to the theme-selection
+handler risks missing a theme-change path and leaving an effect wrongly
+colored until restart. Self-healing beats the micro-win. Not done on purpose.
 
 ## Verification per step
 

--- a/internal/animations/cracktro.go
+++ b/internal/animations/cracktro.go
@@ -1,7 +1,6 @@
 package animations
 
 import (
-	"fmt"
 	"math"
 	"math/rand"
 	"strings"
@@ -180,16 +179,23 @@ func (c *CracktroAnimation) Render() string {
 	}
 
 	for y := 0; y < c.height; y++ {
+		// Run-length SGR state: emit a color code only when the color changes
+		// along the row, reset before default-colored cells and at row end
+		lastR, lastG, lastB := -1, -1, -1
+
 		for x := 0; x < c.width; x++ {
 			pos := [2]int{x, y}
+
+			var cr, cg, cb int
+			var ch rune
+			colored := true
 
 			if bh, ok := barMap[y]; ok {
 				col := c.cracktroSlot(bh.colorIdx)
 				r, g, b := hexToRGBCracktro(col)
-				r = cracktroClamp(int(float64(r)*bh.intensity), 0, 255)
-				g = cracktroClamp(int(float64(g)*bh.intensity), 0, 255)
-				b = cracktroClamp(int(float64(b)*bh.intensity), 0, 255)
-				var ch rune
+				cr = cracktroClamp(int(float64(r)*bh.intensity), 0, 255)
+				cg = cracktroClamp(int(float64(g)*bh.intensity), 0, 255)
+				cb = cracktroClamp(int(float64(b)*bh.intensity), 0, 255)
 				if bh.intensity > 0.8 {
 					ch = '\u2588'
 				} else if bh.intensity > 0.6 {
@@ -199,14 +205,9 @@ func (c *CracktroAnimation) Render() string {
 				} else {
 					ch = '\u2591'
 				}
-				fmt.Fprintf(&c.builder, "\033[38;2;%d;%d;%dm%c\033[0m", r, g, b, ch)
-				continue
-			}
-
-			if layer, ok := starMap[pos]; ok {
+			} else if layer, ok := starMap[pos]; ok {
 				col := c.cracktroSlot(layer)
-				r, g, b := hexToRGBCracktro(col)
-				var ch rune
+				cr, cg, cb = hexToRGBCracktro(col)
 				switch layer {
 				case 0:
 					ch = '\u00b7'
@@ -215,11 +216,28 @@ func (c *CracktroAnimation) Render() string {
 				case 2:
 					ch = '*'
 				}
-				fmt.Fprintf(&c.builder, "\033[38;2;%d;%d;%dm%c\033[0m", r, g, b, ch)
+			} else {
+				colored = false
+			}
+
+			if !colored {
+				if lastR != -1 {
+					c.builder.WriteString("\x1b[0m")
+					lastR, lastG, lastB = -1, -1, -1
+				}
+				c.builder.WriteByte(' ')
 				continue
 			}
 
-			c.builder.WriteByte(' ')
+			if cr != lastR || cg != lastG || cb != lastB {
+				writeRGBSGR(&c.builder, cr, cg, cb)
+				lastR, lastG, lastB = cr, cg, cb
+			}
+			c.builder.WriteRune(ch)
+		}
+
+		if lastR != -1 {
+			c.builder.WriteString("\x1b[0m")
 		}
 		if y < c.height-1 {
 			c.builder.WriteByte('\n')

--- a/internal/animations/fire.go
+++ b/internal/animations/fire.go
@@ -2,9 +2,6 @@ package animations
 
 import (
 	"math/rand"
-	"strings"
-
-	"github.com/charmbracelet/lipgloss/v2"
 )
 
 // FireEffect implements PSX DOOM-style fire algorithm
@@ -102,17 +99,16 @@ func (f *FireEffect) Update(frame int) {
 
 // Render converts the fire buffer to colored text output
 func (f *FireEffect) Render() string {
-	var lines []string
+	w := newSGRLineWriter(f.width * f.height * 4)
 
 	// Render across full height - low heat at top will naturally fade to black/background
 	for y := 0; y < f.height; y++ {
-		var line strings.Builder
 		for x := 0; x < f.width; x++ {
 			heat := f.buffer[y*f.width+x]
 
 			// Skip very low heat (natural fade to background)
 			if heat < 3 {
-				line.WriteString(" ")
+				w.WriteCell("", ' ')
 				continue
 			}
 
@@ -121,23 +117,17 @@ func (f *FireEffect) Render() string {
 			if charIndex >= len(f.chars) {
 				charIndex = len(f.chars) - 1
 			}
-			char := f.chars[charIndex]
 
 			// Map heat to color from palette
 			colorIndex := heat * (len(f.palette) - 1) / 36
 			if colorIndex >= len(f.palette) {
 				colorIndex = len(f.palette) - 1
 			}
-			colorHex := f.palette[colorIndex]
 
-			// Render colored character
-			styled := lipgloss.NewStyle().
-				Foreground(lipgloss.Color(colorHex)).
-				Render(string(char))
-			line.WriteString(styled)
+			w.WriteCell(f.palette[colorIndex], f.chars[charIndex])
 		}
-		lines = append(lines, line.String())
+		w.EndRow()
 	}
 
-	return strings.Join(lines, "\n")
+	return w.String()
 }

--- a/internal/animations/matrix.go
+++ b/internal/animations/matrix.go
@@ -2,9 +2,6 @@ package animations
 
 import (
 	"math/rand"
-	"strings"
-
-	"github.com/charmbracelet/lipgloss/v2"
 )
 
 // MatrixEffect implements Matrix digital rain animation using particle-based streaks
@@ -232,23 +229,18 @@ func (m *MatrixEffect) Render() string {
 	}
 
 	// Convert to colored string
-	var lines []string
+	w := newSGRLineWriter(m.width * m.height * 2)
 	for y := 0; y < m.height; y++ {
-		var line strings.Builder
 		for x := 0; x < m.width; x++ {
 			char := canvas[y][x]
 			if char != ' ' && colors[y][x] != "" {
-				// Render colored character
-				styled := lipgloss.NewStyle().
-					Foreground(lipgloss.Color(colors[y][x])).
-					Render(string(char))
-				line.WriteString(styled)
+				w.WriteCell(colors[y][x], char)
 			} else {
-				line.WriteRune(char)
+				w.WriteCell("", char)
 			}
 		}
-		lines = append(lines, line.String())
+		w.EndRow()
 	}
 
-	return strings.Join(lines, "\n")
+	return w.String()
 }

--- a/internal/animations/perf_bench_test.go
+++ b/internal/animations/perf_bench_test.go
@@ -1,0 +1,75 @@
+package animations
+
+import (
+	"testing"
+)
+
+// Perf audit benchmarks — fullscreen kitty on 1080p ≈ 240x67 cells.
+const (
+	benchW = 240
+	benchH = 67
+)
+
+func BenchmarkFireUpdate(b *testing.B) {
+	f := NewFireEffect(benchW, benchH*2/5, GetDefaultFirePalette())
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		f.Update(i)
+	}
+}
+
+func BenchmarkFireRender(b *testing.B) {
+	f := NewFireEffect(benchW, benchH*2/5, GetDefaultFirePalette())
+	for i := 0; i < 60; i++ {
+		f.Update(i)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = f.Render()
+	}
+}
+
+func BenchmarkMatrixUpdate(b *testing.B) {
+	m := NewMatrixEffect(benchW, benchH, GetMatrixPalette("default"))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		m.Update(i)
+	}
+}
+
+func BenchmarkMatrixRender(b *testing.B) {
+	m := NewMatrixEffect(benchW, benchH, GetMatrixPalette("default"))
+	for i := 0; i < 60; i++ {
+		m.Update(i)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = m.Render()
+	}
+}
+
+func BenchmarkRainRender(b *testing.B) {
+	r := NewRainEffect(benchW, benchH, GetRainPalette("default"))
+	for i := 0; i < 60; i++ {
+		r.Update(i)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = r.Render()
+	}
+}
+
+func BenchmarkPlasmaUpdateRender(b *testing.B) {
+	p := NewPlasmaEffect(benchW, benchH, GetPlasmaPalette("default"), "default")
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		p.Update()
+		_ = p.Render()
+	}
+}
+
+func BenchmarkGetMatrixPalette(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = GetMatrixPalette("dracula")
+	}
+}

--- a/internal/animations/plasma.go
+++ b/internal/animations/plasma.go
@@ -1,7 +1,6 @@
 package animations
 
 import (
-	"fmt"
 	"math"
 	"math/rand"
 	"strings"
@@ -43,7 +42,7 @@ func NewPlasmaEffect(width, height int, palette []string, theme string) *PlasmaA
 		palette:      palette,
 		theme:        theme,
 		phase:        PlasmaFadeIn,
-		fadeInFrames:  40,
+		fadeInFrames: 40,
 		paletteShift: 0,
 	}
 	p.initBlobs()
@@ -133,6 +132,10 @@ func (p *PlasmaAnimation) Render() string {
 			scanlineDim = 0.85
 		}
 
+		// Run-length SGR state: only emit a color code when the pixel color
+		// changes along the row (replaces one Fprintf + reset per pixel)
+		lastR, lastG, lastB := -1, -1, -1
+
 		for cx := 0; cx < chunkyW; cx++ {
 			// Center of this chunky pixel
 			px := float64(cx*2) + 1.0
@@ -221,8 +224,22 @@ func (p *PlasmaAnimation) Render() string {
 			finalB := plasmaClamp(int(weightedB*intensity*scanlineDim*fade), 0, 255)
 
 			// Write chunky pixel (2 chars wide)
-			fmt.Fprintf(&p.builder, "\033[38;2;%d;%d;%dm%c%c\033[0m", finalR, finalG, finalB, ch, ch)
+			if finalR != lastR || finalG != lastG || finalB != lastB {
+				p.builder.WriteString("\x1b[38;2;")
+				writeByteDecimal(&p.builder, finalR)
+				p.builder.WriteByte(';')
+				writeByteDecimal(&p.builder, finalG)
+				p.builder.WriteByte(';')
+				writeByteDecimal(&p.builder, finalB)
+				p.builder.WriteByte('m')
+				lastR, lastG, lastB = finalR, finalG, finalB
+			}
+			p.builder.WriteRune(ch)
+			p.builder.WriteRune(ch)
 		}
+
+		// Reset at row end so colors never bleed into layer padding
+		p.builder.WriteString("\x1b[0m")
 
 		// Fill remaining columns if width is odd
 		if p.width%2 != 0 {

--- a/internal/animations/plasma.go
+++ b/internal/animations/plasma.go
@@ -225,13 +225,7 @@ func (p *PlasmaAnimation) Render() string {
 
 			// Write chunky pixel (2 chars wide)
 			if finalR != lastR || finalG != lastG || finalB != lastB {
-				p.builder.WriteString("\x1b[38;2;")
-				writeByteDecimal(&p.builder, finalR)
-				p.builder.WriteByte(';')
-				writeByteDecimal(&p.builder, finalG)
-				p.builder.WriteByte(';')
-				writeByteDecimal(&p.builder, finalB)
-				p.builder.WriteByte('m')
+				writeRGBSGR(&p.builder, finalR, finalG, finalB)
 				lastR, lastG, lastB = finalR, finalG, finalB
 			}
 			p.builder.WriteRune(ch)

--- a/internal/animations/rain.go
+++ b/internal/animations/rain.go
@@ -2,9 +2,6 @@ package animations
 
 import (
 	"math/rand"
-	"strings"
-
-	"github.com/charmbracelet/lipgloss/v2"
 )
 
 // RainEffect implements ascii rain animation
@@ -129,10 +126,13 @@ func (r *RainEffect) Update(frame int) {
 
 // Render converts the rain drops to colored text output
 func (r *RainEffect) Render() string {
-	// Create empty canvas
+	// Create empty canvas; track colors alongside so the render loop doesn't
+	// scan the drop list for every cell
 	canvas := make([][]rune, r.height)
+	colors := make([][]string, r.height)
 	for i := range canvas {
 		canvas[i] = make([]rune, r.width)
+		colors[i] = make([]string, r.width)
 		for j := range canvas[i] {
 			canvas[i][j] = ' '
 		}
@@ -142,36 +142,27 @@ func (r *RainEffect) Render() string {
 	for _, drop := range r.drops {
 		if drop.X >= 0 && drop.X < r.width && drop.Y >= 0 && drop.Y < r.height {
 			canvas[drop.Y][drop.X] = drop.Char
+			colors[drop.Y][drop.X] = drop.Color
 		}
 	}
 
 	// Convert to colored string
-	var lines []string
+	w := newSGRLineWriter(r.width * r.height * 2)
 	for y := 0; y < r.height; y++ {
-		var line strings.Builder
 		for x := 0; x < r.width; x++ {
 			char := canvas[y][x]
 			if char != ' ' {
-				// Find the drop at this position to get its color
-				color := "#00ff00" // Default color
-				for _, drop := range r.drops {
-					if drop.X == x && drop.Y == y {
-						color = drop.Color
-						break
-					}
+				color := colors[y][x]
+				if color == "" {
+					color = "#00ff00" // Default color
 				}
-
-				// Render colored character
-				styled := lipgloss.NewStyle().
-					Foreground(lipgloss.Color(color)).
-					Render(string(char))
-				line.WriteString(styled)
+				w.WriteCell(color, char)
 			} else {
-				line.WriteRune(char)
+				w.WriteCell("", char)
 			}
 		}
-		lines = append(lines, line.String())
+		w.EndRow()
 	}
 
-	return strings.Join(lines, "\n")
+	return w.String()
 }

--- a/internal/animations/render_invariants_test.go
+++ b/internal/animations/render_invariants_test.go
@@ -1,0 +1,65 @@
+package animations
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+)
+
+// Layer compositing requires every effect frame to be a full width x height
+// grid, and colors must never remain open past a row's end or they bleed into
+// layer padding (ghosting, see e265c41). These tests pin that contract for
+// the run-length SGR renderers.
+
+func checkFrame(t *testing.T, name, frame string, width, height int) {
+	t.Helper()
+	lines := strings.Split(frame, "\n")
+	if len(lines) != height {
+		t.Fatalf("%s: got %d rows, want %d", name, len(lines), height)
+	}
+	for i, line := range lines {
+		if w := ansi.StringWidth(line); w != width {
+			t.Errorf("%s: row %d visible width %d, want %d", name, i, w, width)
+		}
+		if idx := strings.LastIndex(line, "\x1b[38;"); idx != -1 {
+			if !strings.Contains(line[idx:], "\x1b[0m") {
+				t.Errorf("%s: row %d leaves color state open past row end", name, i)
+			}
+		}
+	}
+}
+
+func TestFireRenderInvariants(t *testing.T) {
+	f := NewFireEffect(120, 40, GetDefaultFirePalette())
+	for i := 0; i < 30; i++ {
+		f.Update(i)
+	}
+	checkFrame(t, "fire", f.Render(), 120, 40)
+}
+
+func TestMatrixRenderInvariants(t *testing.T) {
+	m := NewMatrixEffect(120, 40, GetMatrixPalette("default"))
+	for i := 0; i < 30; i++ {
+		m.Update(i)
+	}
+	checkFrame(t, "matrix", m.Render(), 120, 40)
+}
+
+func TestRainRenderInvariants(t *testing.T) {
+	r := NewRainEffect(120, 40, GetRainPalette("default"))
+	for i := 0; i < 30; i++ {
+		r.Update(i)
+	}
+	checkFrame(t, "rain", r.Render(), 120, 40)
+}
+
+func TestPlasmaRenderInvariants(t *testing.T) {
+	for _, width := range []int{120, 121} { // even and odd: odd pads the last column
+		p := NewPlasmaEffect(width, 40, GetPlasmaPalette("default"), "default")
+		for i := 0; i < 30; i++ {
+			p.Update()
+		}
+		checkFrame(t, "plasma", p.Render(), width, 40)
+	}
+}

--- a/internal/animations/render_invariants_test.go
+++ b/internal/animations/render_invariants_test.go
@@ -63,3 +63,19 @@ func TestPlasmaRenderInvariants(t *testing.T) {
 		checkFrame(t, "plasma", p.Render(), width, 40)
 	}
 }
+
+func TestSonarRenderInvariants(t *testing.T) {
+	s := NewSonarEffect(120, 40, GetSonarPalette("default"), "default")
+	for i := 0; i < 30; i++ {
+		s.Update()
+	}
+	checkFrame(t, "sonar", s.Render(), 120, 40)
+}
+
+func TestCracktroRenderInvariants(t *testing.T) {
+	c := NewCracktroEffect(120, 40, GetCracktroPalette("default"), "default")
+	for i := 0; i < 30; i++ {
+		c.Update()
+	}
+	checkFrame(t, "cracktro", c.Render(), 120, 40)
+}

--- a/internal/animations/sgr.go
+++ b/internal/animations/sgr.go
@@ -85,6 +85,17 @@ func hexNibble(c byte) int {
 	return 0
 }
 
+// writeRGBSGR writes a truecolor foreground sequence for numeric r,g,b.
+func writeRGBSGR(sb *strings.Builder, r, g, b int) {
+	sb.WriteString("\x1b[38;2;")
+	writeByteDecimal(sb, r)
+	sb.WriteByte(';')
+	writeByteDecimal(sb, g)
+	sb.WriteByte(';')
+	writeByteDecimal(sb, b)
+	sb.WriteByte('m')
+}
+
 func writeByteDecimal(sb *strings.Builder, n int) {
 	if n < 0 || n > 255 {
 		n = 0

--- a/internal/animations/sgr.go
+++ b/internal/animations/sgr.go
@@ -1,0 +1,103 @@
+package animations
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/lipgloss/v2"
+)
+
+// sgrLineWriter builds effect frames by writing truecolor SGR sequences
+// directly, emitting a color code only when the foreground changes along a
+// row. This replaces per-cell lipgloss.NewStyle().Render() calls, which
+// allocate a style and emit a full sequence + reset for every character
+// (measured 39x slower on a fullscreen fire frame).
+//
+// The output is parsed into cells by the compositor (ultraviolet), which
+// re-emits colors according to the detected terminal profile, so truecolor
+// sequences here do not bypass TTY color fallback.
+//
+// Every row is closed with a reset before its newline so colors never bleed
+// into layer padding (ghosting protection, see e265c41).
+type sgrLineWriter struct {
+	sb      strings.Builder
+	current string // hex color of the active SGR state; "" = terminal default
+}
+
+func newSGRLineWriter(capacity int) *sgrLineWriter {
+	w := &sgrLineWriter{}
+	w.sb.Grow(capacity)
+	return w
+}
+
+// WriteCell writes one rune with the given "#rrggbb" foreground.
+// An empty color writes the rune in the terminal default.
+func (w *sgrLineWriter) WriteCell(hex string, r rune) {
+	if hex != w.current {
+		if hex == "" {
+			w.sb.WriteString("\x1b[0m")
+		} else if len(hex) == 7 && hex[0] == '#' {
+			w.sb.WriteString("\x1b[38;2;")
+			writeByteDecimal(&w.sb, hexPair(hex[1], hex[2]))
+			w.sb.WriteByte(';')
+			writeByteDecimal(&w.sb, hexPair(hex[3], hex[4]))
+			w.sb.WriteByte(';')
+			writeByteDecimal(&w.sb, hexPair(hex[5], hex[6]))
+			w.sb.WriteByte('m')
+		} else {
+			// Non-hex color (should not happen with palette colors):
+			// fall back to lipgloss and clear run-length state
+			w.sb.WriteString(lipgloss.NewStyle().Foreground(lipgloss.Color(hex)).Render(string(r)))
+			w.current = ""
+			return
+		}
+		w.current = hex
+	}
+	w.sb.WriteRune(r)
+}
+
+// EndRow resets the SGR state and terminates the row.
+func (w *sgrLineWriter) EndRow() {
+	if w.current != "" {
+		w.sb.WriteString("\x1b[0m")
+		w.current = ""
+	}
+	w.sb.WriteByte('\n')
+}
+
+// String returns the frame without the trailing newline of the last row.
+func (w *sgrLineWriter) String() string {
+	return strings.TrimSuffix(w.sb.String(), "\n")
+}
+
+func hexPair(hi, lo byte) int {
+	return hexNibble(hi)<<4 | hexNibble(lo)
+}
+
+func hexNibble(c byte) int {
+	switch {
+	case c >= '0' && c <= '9':
+		return int(c - '0')
+	case c >= 'a' && c <= 'f':
+		return int(c-'a') + 10
+	case c >= 'A' && c <= 'F':
+		return int(c-'A') + 10
+	}
+	return 0
+}
+
+func writeByteDecimal(sb *strings.Builder, n int) {
+	if n < 0 || n > 255 {
+		n = 0
+	}
+	var buf [3]byte
+	i := 3
+	for {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+		if n == 0 {
+			break
+		}
+	}
+	sb.Write(buf[i:])
+}

--- a/internal/animations/sonar.go
+++ b/internal/animations/sonar.go
@@ -365,8 +365,16 @@ func (s *SonarAnimation) Render() string {
 	scanColor := s.paletteSlot(2)
 
 	for y := 0; y < s.height; y++ {
+		// Run-length SGR state: emit a color code only when the color changes
+		// along the row, reset before default-colored cells and at row end
+		lastR, lastG, lastB := -1, -1, -1
+
 		for x := 0; x < s.width; x++ {
 			pos := [2]int{x, y}
+
+			var cr, cg, cb int
+			var ch rune
+			colored := true
 
 			if ap, ok := ashMap[pos]; ok {
 				var col string
@@ -375,31 +383,40 @@ func (s *SonarAnimation) Render() string {
 				} else {
 					col = s.paletteSlot(6)
 				}
-				r, g, b := hexToRGBSonar(col)
-				fmt.Fprintf(&s.builder, "\033[38;2;%d;%d;%dm%c\033[0m", r, g, b, ap.char)
-				continue
-			}
-
-			if y == scanY {
-				r, g, b := hexToRGBSonar(scanColor)
-				fmt.Fprintf(&s.builder, "\033[38;2;%d;%d;%dm─\033[0m", r, g, b)
-				continue
-			}
-
-			if h, ok := ringMap[pos]; ok {
+				cr, cg, cb = hexToRGBSonar(col)
+				ch = ap.char
+			} else if y == scanY {
+				cr, cg, cb = hexToRGBSonar(scanColor)
+				ch = '─'
+			} else if h, ok := ringMap[pos]; ok {
 				col := hexLerp(s.paletteSlot(0), s.paletteSlot(1), h.intensity)
-				r, g, b := hexToRGBSonar(col)
-				fmt.Fprintf(&s.builder, "\033[38;2;%d;%d;%dm·\033[0m", r, g, b)
+				cr, cg, cb = hexToRGBSonar(col)
+				ch = '·'
+			} else if gch, ok := gridMap[pos]; ok {
+				cr, cg, cb = hexToRGBSonar(gridColor)
+				ch = gch
+			} else {
+				colored = false
+			}
+
+			if !colored {
+				if lastR != -1 {
+					s.builder.WriteString("\x1b[0m")
+					lastR, lastG, lastB = -1, -1, -1
+				}
+				s.builder.WriteByte(' ')
 				continue
 			}
 
-			if ch, ok := gridMap[pos]; ok {
-				r, g, b := hexToRGBSonar(gridColor)
-				fmt.Fprintf(&s.builder, "\033[38;2;%d;%d;%dm%c\033[0m", r, g, b, ch)
-				continue
+			if cr != lastR || cg != lastG || cb != lastB {
+				writeRGBSGR(&s.builder, cr, cg, cb)
+				lastR, lastG, lastB = cr, cg, cb
 			}
+			s.builder.WriteRune(ch)
+		}
 
-			s.builder.WriteByte(' ')
+		if lastR != -1 {
+			s.builder.WriteString("\x1b[0m")
 		}
 		if y < s.height-1 {
 			s.builder.WriteByte('\n')

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -8,16 +8,23 @@ echo "==> Setting up sysc-greet..."
 # Create greeter user if it doesn't exist
 if ! id greeter &>/dev/null; then
     echo "==> Creating greeter user..."
-    useradd -M -G video,render,input -s /usr/bin/nologin greeter
+    useradd -M -d /var/lib/greeter -G video,render,input -s /usr/bin/nologin greeter
 else
     echo "==> Updating greeter user groups..."
-    usermod -aG video,render,input greeter
+    usermod -d /var/lib/greeter -aG video,render,input greeter
 fi
 
 # Set permissions
 echo "==> Setting permissions..."
+mkdir -p /var/cache/sysc-greet \
+    /var/lib/greeter/Pictures/wallpapers \
+    /var/lib/greeter/.cache \
+    /var/lib/greeter/.config \
+    /var/lib/greeter/.local/state \
+    /tmp/greeter-cache
 chown -R greeter:greeter /var/cache/sysc-greet 2>/dev/null || true
 chown -R greeter:greeter /var/lib/greeter 2>/dev/null || true
+chown -R greeter:greeter /tmp/greeter-cache 2>/dev/null || true
 chmod 755 /var/lib/greeter
 
 # Detect installed Wayland backend and configure greetd


### PR DESCRIPTION
Implements the [2026-07-07 perf audit](docs/superpowers/audits/2026-07-07-perf-audit.md). Plan with regression constraints from git history: `docs/superpowers/plans/2026-07-07-perf-render-loop-plan.md`.

## Results (240x67 pty, Ryzen 5700X, sysc-greet process only — kitty pays a similar cost again)

| Config | Before | After |
|---|---|---|
| Idle login (user present) | 53% CPU | 31% |
| **Idle login (>60s no input)** | **53% CPU, 1.0 MiB/s output** | **5.9% CPU, ~0.4 MiB/s** |
| fire | 84% | 44% |
| matrix | 60% | 44% |
| plasma | 77% | 69% |

| Render benchmark (per frame) | Before | After |
|---|---|---|
| fire | 5.3 ms / 24,459 allocs | 0.13 ms / 3 allocs |
| matrix | 2.6 ms / 9,891 | 0.26 ms / 138 |
| rain | 1.8 ms / 5,870 | 0.20 ms / 137 |
| plasma (update+render) | 2.1 ms / 10,267 | 1.0 ms / 25 |

## Changes (one commit each)

1. **Screensaver config cached** — was opened and parsed from disk 33x/s in the tick handler and again per frame in screensaver mode. Now loaded at startup, refreshed at most once per minute (live edits still apply).
2. **Background tick chain idles** — with no effect selected (or a mode that can't display one), the chain reschedules at 250ms and skips all work instead of running at 15–60ms.
3. **UI tick drops to 1s when idle** — after 60s without input (and nothing wall-clock-animated on screen), the 30ms tick becomes 1s and the animation counters freeze, so frames are byte-identical and diff to nothing. Any key returns to 30ms within a second. Screensaver activation and clock only need 1s resolution.
4. **Run-length SGR rendering** — fire/matrix/rain (new shared `sgrLineWriter`), plasma/sonar/cracktro (numeric-RGB variant): one color sequence per color run instead of a lipgloss style allocation + full sequence + reset per cell. Rows always end reset so colors can't bleed into layer padding.
5. **Real-greeter follow-ups from laptop testing** — cagebreak reinstall now gives the `greeter` account `/var/lib/greeter` as home/cwd and sets writable XDG cache/config/state paths for child processes. `--debug` no longer writes menu/key chatter to stdout/stderr, and password-field key text is redacted in the file log, so debug mode does not corrupt the Bubble Tea UI or leak password input.

## Regression constraints respected (from git history)

- **View() purity** (issue #45 "hyperspeed" bug): all changes live in Update handlers and tick scheduling; render functions untouched semantically.
- **Single tick chains only**: idle gating adapts the interval of the existing chains; no chain is ever spawned from an event handler.
- **animSpeed semantics** (slow/normal/fast) unchanged while effects are active.
- **Ghosting protections** (e265c41): blank backing layer untouched; new `render_invariants_test.go` pins every effect frame to exactly width×height cells with no color state open past a row end.
- **Lazy inits** (aquarium/sonar/cracktro/plasma/gslapper) keep the fast tick until they have fired.

Not converted (low value): fireworks (styles cached per particle already), aquarium/beams/pour/print (banner-area or sparse). Per-tick palette sync kept deliberately — self-healing beats the ~2μs/frame it costs.

Also adds `SYSC_BG` (test mode only): `SYSC_BG=fire sysc-greet --test` selects a background directly for testing.

## Verification

- [x] `go test ./...`
- [x] `make both`
- [x] Render benchmarks show expected allocation drops
- [x] Real greetd + cagebreak + kitty login succeeds after reinstall
- [x] Sampled effects looked visually correct on laptop hardware
- [x] Debug mode no longer emits debug menu/key output into the TUI and redacts password key text

## Visual checklist before merge (real kitty)

- [x] fire / matrix / plasma sampled in real greetd+cagebreak and looked correct
- [x] Login path through real greetd+cagebreak succeeds
- [x] Menus usable after debug-output cleanup; no debug text drawn over selection UI
- [ ] Banner gradient animates while typing; freezes ~60s after last input; resumes on key press (≤1s)
- [ ] rain / sonar / cracktro look identical to before (colors, density, speed)
- [ ] Ticker background scrolls smoothly; animation speed menu (slow/normal/fast) still changes effect speed
- [ ] Menus open/close with no ghosting; power menu clean
- [ ] Screensaver activates on timeout, clock ticks, print animation plays, exits on key
- [ ] Background selection in menu takes effect immediately on return to login

